### PR TITLE
Add recommended VSCode extensions, build task and extension settings #332dukp

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "Armitxes.sqf",
+        "bux578.vscode-openlastrpt",
+        "EditorConfig.EditorConfig",
+        "psioniq.psi-header",
+        "skacekachna.sqflint"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,50 @@
         "missionProfileNamespace",
         "saveMissionProfileNamespace",
     ],
+    //---- START Automatic file headers
+    "psi-header.changes-tracking": {
+        "isActive": true,
+        "include": ["sqf"],
+        "modDate": "Last Update:",
+        "modDateFormat": "YYYY-MM-DD",
+        "autoHeader": "manualSave"
+    },
+    "psi-header.lang-config": [
+        {
+            "license": "Custom",
+            "language": "sqf",
+            "rootDirFileName": "common_includes.hpp",
+            "beforeHeader": [],
+            "begin": "/*",
+            "prefix": "    ",
+            "end": " */",
+            "blankLinesAfter": 1,
+            "forceToTop": true
+        }
+    ],
+    "psi-header.templates": [
+        {
+            "language": "sqf",
+            "template": [
+                "File: <<filename>>",
+                "Author: ",
+                "Date: <<filecreated('YYYY-MM-DD')>>",
+                "Last Update:",
+                "Public: No",
+                "",
+                "Description:",
+                "    No description added yet.",
+                "",
+                "Parameter(s):",
+                "    N/A",
+                "",
+                "Returns:",
+                "    Something [BOOL]",
+                "",
+                "Example(s):",
+                "    [parameter] call vgm_X_fnc_component_myFunction"
+            ]
+        }
+    ],
+    //---- END Automatic file headers
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "sqflint.ignoredVariables": [
+        "missionProfileNamespace",
+        "saveMissionProfileNamespace",
+    ],
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build",
+            "type": "shell",
+            "command": "python3 '${workspaceFolder}\\build\\build.py' build --overwrite",
+            "problemMatcher": [],
+            "group": {
+                "kind": "build"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Adds a list of recommended extensions if using VSCode:
- [Armitxes.sqf](https://github.com/Armitxes/VSCode_SQF) - SQF highlighting and syntax completion
- [bux578.vscode-openlastrpt](https://marketplace.visualstudio.com/items?itemName=bux578.vscode-openlastrpt) - Open last RPT with `Ctrl + Alt + R`
- [EditorConfig.EditorConfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) - `.editorconfig` file support
- [psioniq.psi-header](https://marketplace.visualstudio.com/items?itemName=psioniq.psi-header) - Automatic header insertion for new SQF files and Last Updated date tracking
- [skacekachna.sqflint](https://marketplace.visualstudio.com/items?itemName=skacekachna.sqflint) - SQF syntax validation, not perfect but mostly works. Quite popular extension.

It also adds build task settings so you can conveniently run the mission build script from VSC.