### PR TITLE
Move user facing strings to stringtable #332dvkq

### DIFF
--- a/game/maps/cam_lao_nam/mission.sqm
+++ b/game/maps/cam_lao_nam/mission.sqm
@@ -404,7 +404,7 @@ class Mission
     appId=1227700;
     class Intel
     {
-        briefingName="Mike Force (v1.00.01+ Indev)";
+        briefingName="GAMEMODE_NAME (#VERSION# Indev)";
         resistanceWest=0;
         timeOfChanges=1800.0002;
         startWeather=0.34999999;

--- a/game/mission/description.ext
+++ b/game/mission/description.ext
@@ -1,8 +1,7 @@
 #include "common_includes.hpp"
-#include "version.hpp"
 
 //Allow calling verson number from mission functions
-version = VGM_VERSION;
+version = "$STR_VGM_MISSION_VERSION";
 
 // Used to find certain paths
 #define VGM_PATH
@@ -20,14 +19,18 @@ respawnDialog = 0;
 respawnButton = 1;
 respawnOnStart = -1;
 respawnTemplates[] = { "MenuPosition" };
+
 onPauseScript = "";
-onLoadMission = QUOTE(ANARCHY (VGM_VERSION));
-OnLoadIntro = "Welcome to Vietnam [Placeholder]";
+
+onLoadName = "$STR_VGM_MISSION_NAME";
+onLoadMission = "$STR_VGM_MISSION_VERSION";
+onLoadIntro = "$STR_VGM_MISSION_INTRO";
+briefingName = "$STR_VGM_MISSION_NAME_VERSION";
+
 loadScreen = "";
 OnLoadIntroTime = 0;
 OnLoadMissionTime = 0;
-briefingName = QUOTE(ANARCHY (VGM_VERSION));
-onLoadName = QUOTE(ANARCHY (VGM_VERSION));
+
 overviewPicture = "";
 
 disabledAI = 1;

--- a/game/mission/stringtable.xml
+++ b/game/mission/stringtable.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project name="VGM">
+    <Package name="General">
+        <Key ID="STR_VGM_MISSION_NAME_VERSION">
+            <Original>GAMEMODE_NAME (#VERSION#)</Original>
+        </Key>
+        <Key ID="STR_VGM_MISSION_NAME">
+            <Original>GAMEMODE_NAME</Original>
+        </Key>
+        <Key ID="STR_VGM_MISSION_VERSION">
+            <Original>#VERSION#</Original>
+        </Key>
+        <Key ID="STR_VGM_MISSION_INTRO">
+            <Original>Welcome to Vietnam [Placeholder]</Original>
+        </Key>
+    </Package>
+</Project>

--- a/game/mission/version.hpp
+++ b/game/mission/version.hpp
@@ -1,2 +1,0 @@
-// Remember to update this in the mission.sqm too!
-#define VGM_VERSION PLACEHOLDER_VERSION


### PR DESCRIPTION
Moves user-visible strings to stringtable.

Also removes the `version` from the mission config file and moves it to stringtable. The version is a static placeholder for now but it should be set by the build tool.