### PR TITLE
Add vgm_version global variable

### DIFF
--- a/game/functions/core/client/ui/fn_handle_welcome_screen.sqf
+++ b/game/functions/core/client/ui/fn_handle_welcome_screen.sqf
@@ -2,7 +2,7 @@
     File: fn_handle_welcome_screen.sqf
     Author: Gus Schultz
     Date: 2022-09-18
-    Last Update:
+    Last Update: 2022-11-13
     Public: /shrug
 
     Description:
@@ -21,15 +21,14 @@
 [] spawn
 {
     uiSleep 2;
-    private _version = getText(missionConfigFile >> "version");
     private _lastVersion = (["GET", "last_version", ""] call para_s_fnc_profile_db) select 1;
     //Open welcome screen for new players
     private _welcomeScreenEnabled = ["para_enableWelcomeScreen"] call para_c_fnc_optionsMenu_getValue;
-    private _versionHasChanged = _lastVersion == "" || _lastVersion != _version;
+    private _versionHasChanged = _lastVersion == "" || _lastVersion != vgm_version;
 
     if (_versionHasChanged) exitWith {
         createDialog "para_ChangelogScreen";
-        ["SET", "last_version", _version] call para_s_fnc_profile_db;
+        ["SET", "last_version", vgm_version] call para_s_fnc_profile_db;
     };
 
     if (_welcomeScreenEnabled == 1) exitWith {

--- a/game/functions/core/global/fn_preInit.sqf
+++ b/game/functions/core/global/fn_preInit.sqf
@@ -6,7 +6,7 @@
     Public: No
 
     Description:
-        Core component preInit script.
+        Core component global preInit script.
  */
 
 vgm_version = localize "STR_VGM_MISSION_VERSION";

--- a/game/functions/core/global/fn_preInit.sqf
+++ b/game/functions/core/global/fn_preInit.sqf
@@ -1,0 +1,12 @@
+/*
+    File: fn_preInit.sqf
+    Author: Savage Games Design
+    Date: 2022-11-13
+    Last Update: 2022-11-13
+    Public: No
+
+    Description:
+        Core component preInit script.
+ */
+
+vgm_version = localize "STR_VGM_MISSION_VERSION";

--- a/game/functions/core/global/fn_preInit.sqf
+++ b/game/functions/core/global/fn_preInit.sqf
@@ -1,6 +1,6 @@
 /*
     File: fn_preInit.sqf
-    Author: Savage Games Design
+    Author: Savage Game Design
     Date: 2022-11-13
     Last Update: 2022-11-13
     Public: No

--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -27,5 +27,15 @@ class vgm_g
     {
         VGM_GLOBAL_PATH(\);
     };
+
+    class core
+    {
+        VGM_GLOBAL_PATH(\core\global);
+
+        class preInit
+        {
+            preInit = 1;
+        };
+    };
 };
 


### PR DESCRIPTION
- title

The `version` entry was removed from mission config in #6, doing it constantly via config lookups is slower than GVAR access so this should be better anyway.