### PR TITLE
Fix global event handlers not called if no specific origin handlers present

### DIFF
--- a/paradigm/global/functions/events/internal/fn_event_callRegisteredHandlers.sqf
+++ b/paradigm/global/functions/events/internal/fn_event_callRegisteredHandlers.sqf
@@ -2,7 +2,7 @@
     File: fn_event_callRegisteredHandlers.sqf
     Author: Savage Game Design
     Date: 2022-11-21
-    Last Update: 2023-04-14
+    Last Update: 2023-06-01
     Public: No
 
     Description:
@@ -29,6 +29,11 @@ private _eventListenersByOrigin = localNamespace getVariable "para_event_listene
 // This handles global listeners + general topic, due to the format the listeners are stored in.
 // See attachHandler for more information.
 private _handlerIdsToCall = flatten (_eventListenersByOrigin getOrDefault [_originMachineId, createHashMap] getOrDefault [_hashableEvent, []]);
+
+// Fallback to global handlers if there were no handlers registered for that specific origin
+if (_handlerIdsToCall isEqualTo []) then {
+    _handlerIdsToCall = flatten (_eventListenersByOrigin getOrDefault [0, createHashMap] getOrDefault [_hashableEvent, []]);
+};
 
 if (_handlerIdsToCall isEqualTo []) exitWith {};
 


### PR DESCRIPTION
case 1:
```sqf
// server
["vgm_leveling_init", {diag_log "hello from global handler"}] call para_g_fnc_event_subscribe;

// server
["vgm_leveling_init", player] call para_g_fnc_event_triggerServer; // nothing happens, expected handler to fire
```

case 2:
```sqf
// server
["vgm_leveling_init", {diag_log "hello from global handler"}] call para_g_fnc_event_subscribe;
["vgm_leveling_init", {diag_log "hello from local handler"}] call para_g_fnc_event_subscribeLocal;
// server
["vgm_leveling_init", player] call para_g_fnc_event_triggerServer; // both handlers fire
```

case 3:
```sqf
// server
["vgm_leveling_init", {diag_log "hello from global handler"}] call para_g_fnc_event_subscribe;
["vgm_leveling_init", {diag_log "hello from local handler"}] call para_g_fnc_event_subscribeLocal;
// some client
["vgm_leveling_init", player] call para_g_fnc_event_triggerServer; // nothing happens, expected first handler to fire
```

This is due to how event handlers are stored. In case 1 we access the hashmap by key `2`, but we only have handlers in the key `0`.
In case 2 after we add a specific origin (server/`2`) handler the global handlers array is referenced in that handlers array and it works correctly, but only if receiving events from the machine we have specific origin handlers for.