### PR TITLE
Remove config for non existent function "requestMissionData"

### DIFF
--- a/game/functions/functions_server.hpp
+++ b/game/functions/functions_server.hpp
@@ -48,7 +48,6 @@ class vgm_s
         class missions_remoteExec_createMission {};
         class missions_remoteExec_joinMission {};
         class missions_remoteExec_leaveMission {};
-        class missions_remoteExec_requestMissionData {};
         class missions_remoteExec_setReadiness {};
         class missions_remoteExec_startMission {};
     };


### PR DESCRIPTION
- There's no file for this function

Was not detected due to the build script not removing files when they're removed from source.