### PR TITLE
Leveling - Fix invalid experience limit

### DIFF
--- a/game/functions/debug/client/fn_initDebugMenu.sqf
+++ b/game/functions/debug/client/fn_initDebugMenu.sqf
@@ -3,7 +3,7 @@
     File: fn_initDebugMenu.sqf
     Author: Savage Game Design
     Date: 2023-09-07
-    Last Update: 2023-09-08
+    Last Update: 2023-10-06
     Public: No
 
     Description:
@@ -139,7 +139,10 @@ vgm_c_debugMenuEH = [true, "OnGameInterrupt", {
             private _level = _levelingData get "level";
             _this lnbAddRow ["level", str _level];
             _this lnbAddRow ["xp", str (_levelingData get "experience")];
-            _this lnbAddRow ["next level xp", str (vgm_g_leveling_levelsHashMap get _level get "experienceThreshold")];
+            _this lnbAddRow ["next level xp", [
+                str (vgm_g_leveling_levelsHashMap get _level get "experienceThreshold"),
+                "max"
+            ] select (_level >= vgm_g_leveling_maxLvl)];
         }] call vgm_c_debugMenu_addSection;
 
         // skills data

--- a/game/functions/systems/leveling/global/fn_leveling_preInit.sqf
+++ b/game/functions/systems/leveling/global/fn_leveling_preInit.sqf
@@ -2,7 +2,7 @@
     File: fn_preInit.sqf
     Author: Savage Game Design
     Date: 2023-05-30
-    Last Update: 2023-06-11
+    Last Update: 2023-10-06
     Public: No
 
     Description:
@@ -17,3 +17,4 @@
 
 vgm_g_leveling_levelsHashMap = [missionConfigFile >> "vgm_levels"] call vgm_g_fnc_leveling_parseLevelsCfg;
 vgm_g_leveling_maxLvl = selectMax keys vgm_g_leveling_levelsHashMap;
+vgm_g_leveling_maxExperience = vgm_g_leveling_levelsHashMap get (vgm_g_leveling_maxLvl-1) get "experienceThreshold";

--- a/game/functions/systems/leveling/server/fn_leveling_addExperience.sqf
+++ b/game/functions/systems/leveling/server/fn_leveling_addExperience.sqf
@@ -2,7 +2,7 @@
     File: fn_leveling_addExperience.sqf
     Author: Savage Game Design
     Date: 2023-06-01
-    Last Update: 2023-06-23
+    Last Update: 2023-10-06
     Public: No
 
     Description:
@@ -35,7 +35,7 @@ private _currentExperience = _levelingData get "experience";
 // award the gained XP
 _currentExperience = _currentExperience + _experience;
 // clamp XP to the amount needed to reach max level
-_currentExperience = _currentExperience min (vgm_g_leveling_levelsHashMap get (vgm_g_leveling_maxLvl-1) get "experience");
+_currentExperience = _currentExperience min vgm_g_leveling_maxExperience;
 
 _levelingData set ["experience", _currentExperience];
 


### PR DESCRIPTION
- Due to the invalid logic, the XP was capped at `1786` instead of `52039`.
- Show the max lvl indicator in the debug menu