### PR TITLE
Skills - Fix invalid amount of max SP in tree

### DIFF
--- a/game/functions/core/client/displays/fn_displaySkills.sqf
+++ b/game/functions/core/client/displays/fn_displaySkills.sqf
@@ -96,7 +96,7 @@ switch _mode do {
             private _skillTree = _skillTreePath call vgm_g_fnc_skills_getByPath;
 
             private _skillTreePoints = _skillTree call vgm_g_fnc_skills_getTreeSkillPoints;
-            private _label = format ["%1 (%2/%3)", _skillTree get "displayName", _skillTreePoints, _skillTree get "skillPointsMax"];
+            private _label = format ["%1 (%2/%3 SP)", _skillTree get "displayName", _skillTreePoints, _skillTree get "skillPointsMax"];
 
             _ctrlSkills tvSetText [_x, _label];
         } forEach (_ctrlSkills getVariable "vgm_skillsListTvPaths");

--- a/game/functions/systems/skills/global/fn_skills_parseTreeCfg.sqf
+++ b/game/functions/systems/skills/global/fn_skills_parseTreeCfg.sqf
@@ -2,7 +2,7 @@
     File: fn_skills_parseTreeCfg.sqf
     Author:
     Date: 2023-01-15
-    Last Update: 2023-06-02
+    Last Update: 2023-10-07
     Public: Yes
 
     Description:
@@ -17,6 +17,8 @@
     Example(s):
         [missionConfigFile >> "vgm_skillTrees"] call vgm_g_fnc_skills_parseTreeCfg
  */
+
+// #define FIRST_TIER_EXCLUSIVE
 
 params [
     ["_cfgSkillTrees", configNull, [configNull]]
@@ -69,8 +71,10 @@ private _fnc_parseSkillTree = {
         private _skillPointsMax = _skillTree get "skillPointsMax";
         {
             _skillPointsMax = _skillPointsMax + (_x get "cost");
+            #ifdef FIRST_TIER_EXCLUSIVE
             // only one skill can be invested in first tier, break the loop
             if (_tier == 0) exitWith {};
+            #endif
         } forEach _skills;
         _skillTree set ["skillPointsMax", _skillPointsMax];
 


### PR DESCRIPTION
Related to #60 

Also added "SP" suffix in the skill tree list to make it more obvious it's the amount of skill points in the tree, not skills.