### PR TITLE
Medical - Make explosives less deadly

### DIFF
--- a/game/functions/systems/medical/client/dev/testExplosive.sqf
+++ b/game/functions/systems/medical/client/dev/testExplosive.sqf
@@ -1,0 +1,12 @@
+/*
+    ["GrenadeHand", 15] call compileScript ["functions\systems\medical\client\dev\testExplosive.sqf"];
+
+    vn_grenadehand - VN grenade
+    GrenadeHand - vanilla grenade
+*/
+
+params ["_class", "_distance"];
+
+diag_log text format ["========= EXPOSIVE TEST - %1 | %2 =========", _class, _distance];
+
+createVehicle [_class, player getPos [_distance, getDir player], [], 0, "CAN_COLLIDE"];

--- a/game/functions/systems/medical/client/fn_medical_handleDamage.sqf
+++ b/game/functions/systems/medical/client/fn_medical_handleDamage.sqf
@@ -3,7 +3,7 @@
     File: fn_medical_handleDamage.sqf
     Author: Savage Game Design
     Date: 2023-06-11
-    Last Update: 2023-06-27
+    Last Update: 2023-10-15
     Public: No
 
     Description:
@@ -44,7 +44,8 @@ if (_projectile isEqualTo "" && {isNull _source}) exitWith {
 
 private _hitDamage = _damage - _currentDamage;
 // filter out tiny amounts of damage
-if (_hitDamage < 1e-3) exitWith {_currentDamage};
+private _ignoreThreshold = [0.2, 0.001] select _directHit;
+if (_hitDamage < _ignoreThreshold) exitWith {_currentDamage};
 
 private _downed = lifeState _unit == "INCAPACITATED";
 // prevent unit from being killed when downed


### PR DESCRIPTION
Makes explosives less deadly by filtering small instances of damage, explosives provide multiple hits even at a distance. Set values make it so grenades hurt you badly around ~10m and will down you at smaller distances.

In the future I would like lower the filtering threshold and add a `woundModifier` that will redirect torso hits to hands/legs based on player stance and direction to the explosion. This would increase the value of diving prone for cover.

This implementation should suffice for now.