### PR TITLE
Coefficient - Add override system

### DIFF
--- a/game/functions/core/client/coefficient/fn_coefficient_override.sqf
+++ b/game/functions/core/client/coefficient/fn_coefficient_override.sqf
@@ -2,7 +2,7 @@
     File: fn_coefficient_override.sqf
     Author: Savage Game Design
     Date: 2023-11-26
-    Last Update: 2023-11-26
+    Last Update: 2023-12-02
     Public: Yes
 
     Description:
@@ -38,7 +38,8 @@ if (isNil "_coefficientOverridesMap") then {
     _coefficientOverridesMap = createHashMap;
     _unit setVariable ["vgm_c_coefficient_currentCoefficientsOverrides", _coefficientOverridesMap];
 };
-// set a reason if there's one, onChange function will always be applied
+
+// not possible to override without reason
 if (isNil "_reason") exitWith {
     format ["No reason given: %1 | %2", _coefficient, _override] call vgm_g_fnc_logError;
     false

--- a/game/functions/core/client/coefficient/fn_coefficient_override.sqf
+++ b/game/functions/core/client/coefficient/fn_coefficient_override.sqf
@@ -1,0 +1,63 @@
+/*
+    File: fn_coefficient_override.sqf
+    Author: Savage Game Design
+    Date: 2023-11-26
+    Last Update: 2023-11-26
+    Public: Yes
+
+    Description:
+        Set coefficient override on an unit, the coefficient callback won't apply while it's overriden.
+
+    Parameter(s):
+        _unit - Unit to set the override on [OBJECT]
+        _coefficient - Coefficient name [STRING]
+        _reason - Override reason [STRING]
+        _override - Is overriden with given reason [BOOL, defaults to true]
+
+    Returns:
+        Is overriden [BOOL]
+
+    Example(s):
+        [_healer, "animSpeed", "medical_item", false] call vgm_c_fnc_coefficient_override;
+ */
+
+params [
+    ["_unit", objNull, [objNull]],
+    ["_coefficient", "", [""]],
+    ["_reason", nil, [""]],
+    ["_override", true, [true]]
+];
+
+
+if (!(_coefficient in vgm_c_coefficient_allCoefficients)) exitWith {
+    format ["Invalid coefficient, available values: %1", keys vgm_c_coefficient_allCoefficients] call vgm_g_fnc_logError;
+};
+
+private _coefficientOverridesMap = _unit getVariable "vgm_c_coefficient_currentCoefficientsOverrides";
+if (isNil "_coefficientOverridesMap") then {
+    _coefficientOverridesMap = createHashMap;
+    _unit setVariable ["vgm_c_coefficient_currentCoefficientsOverrides", _coefficientOverridesMap];
+};
+// set a reason if there's one, onChange function will always be applied
+if (isNil "_reason") exitWith {
+    format ["No reason given: %1 | %2", _coefficient, _override] call vgm_g_fnc_logError;
+    false
+};
+
+format ["Setting coefficient override: %1 | %2 | %3", _coefficient, _reason, _override] call vgm_g_fnc_logDebug;
+
+private _coefficientOverrides = _coefficientOverridesMap getOrDefault [_coefficient, createHashMap, true];
+if (_override) then {
+    _coefficientOverrides set [_reason, nil];
+} else {
+    _coefficientOverrides deleteAt _reason;
+};
+
+private _isOverriden = count values _coefficientOverrides > 0;
+
+// if override is not applied anymore fire the onChange callback
+if (!_isOverriden) then {
+    [_unit, _coefficient, nil] call vgm_c_fnc_coefficient_set;
+};
+
+_isOverriden // return

--- a/game/functions/core/client/coefficient/fn_coefficient_set.sqf
+++ b/game/functions/core/client/coefficient/fn_coefficient_set.sqf
@@ -2,7 +2,7 @@
     File: fn_coefficient_set.sqf
     Author: Savage Game Design
     Date: 2023-08-21
-    Last Update: 2023-10-08
+    Last Update: 2023-11-26
     Public: Yes
 
     Description:
@@ -38,26 +38,7 @@ if (!(_coefficient in vgm_c_coefficient_allCoefficients)) exitWith {
 
 private _coefficientMap = _unit getVariable "vgm_c_coefficient_currentCoefficients";
 if (isNil "_coefficientMap") then {
-    format ["Creating current coefficients map: %1", _unit] call vgm_g_fnc_logDebug;
-
-    _coefficientMap = createHashMap;
-    _unit setVariable ["vgm_c_coefficient_currentCoefficients", _coefficientMap];
-    // clear all non persistent coefficients upon respawn
-    _unit addEventHandler ["Respawn", {
-        params ["_unit"];
-        {
-            private _coefficient = _x;
-            {
-                private _reason = _x;
-                private _coefficientValues = _y;
-                // ignore persistent coefficients
-                if (_coefficientValues # 1) then {continue};
-                [_unit, _coefficient, _reason] call vgm_c_fnc_coefficient_remove;
-            } forEach _y;
-            // re-apply persistent coefficient values, needed in case "remove" was not called at least once
-            [_unit, _coefficient, nil] call vgm_c_fnc_coefficient_set;
-        } forEach (_unit getVariable "vgm_c_coefficient_currentCoefficients");
-    }]
+    _coefficientMap = [_unit] call vgm_c_fnc_coefficient_unitInit;
 };
 // set a reason if there's one, onChange function will always be applied
 if (!isNil "_reason") then {
@@ -74,6 +55,9 @@ if (!isNil "_reason") then {
 
 private _calculatedValue = [_unit, _coefficient] call vgm_c_fnc_coefficient_get;
 
-[_unit, _calculatedValue] call (vgm_c_coefficient_allCoefficients get _coefficient get "onChange");
+private _isOverriden = count values ((_unit getVariable ["vgm_c_coefficient_currentCoefficientsOverrides", createHashMap]) getOrDefault [_coefficient, createHashMap]) > 0;
+if (!_isOverriden) then {
+    [_unit, _calculatedValue] call (vgm_c_coefficient_allCoefficients get _coefficient get "onChange");
+};
 
 _calculatedValue // return

--- a/game/functions/core/client/coefficient/fn_coefficient_unitInit.sqf
+++ b/game/functions/core/client/coefficient/fn_coefficient_unitInit.sqf
@@ -1,0 +1,44 @@
+/*
+    File: fn_coefficient_unitInit.sqf
+    Author: Savage Game Design
+    Date: 2023-11-26
+    Last Update: 2023-11-26
+    Public: No
+
+    Description:
+        Init coefficient system on an unit.
+
+    Parameter(s):
+        _unit - Unit to init [OBJECT]
+
+    Returns:
+        Coefficient map of the unit [HASHMAP]
+
+    Example(s):
+        _unit call vgm_c_fnc_coefficient_initUnit;
+ */
+
+params ["_unit"];
+
+format ["Creating current coefficients map: %1", _unit] call vgm_g_fnc_logDebug;
+
+private _coefficientMap = createHashMap;
+_unit setVariable ["vgm_c_coefficient_currentCoefficients", _coefficientMap];
+// clear all non persistent coefficients upon respawn
+_unit addEventHandler ["Respawn", {
+    params ["_unit"];
+    {
+        private _coefficient = _x;
+        {
+            private _reason = _x;
+            private _coefficientValues = _y;
+            // ignore persistent coefficients
+            if (_coefficientValues # 1) then {continue};
+            [_unit, _coefficient, _reason] call vgm_c_fnc_coefficient_remove;
+        } forEach _y;
+        // re-apply persistent coefficient values, needed in case "remove" was not called at least once
+        [_unit, _coefficient, nil] call vgm_c_fnc_coefficient_set;
+    } forEach (_unit getVariable "vgm_c_coefficient_currentCoefficients");
+}];
+
+_coefficientMap // return

--- a/game/functions/debug/client/fn_initDebugMenu.sqf
+++ b/game/functions/debug/client/fn_initDebugMenu.sqf
@@ -3,7 +3,7 @@
     File: fn_initDebugMenu.sqf
     Author: Savage Game Design
     Date: 2023-09-07
-    Last Update: 2023-10-06
+    Last Update: 2023-11-26
     Public: No
 
     Description:
@@ -105,7 +105,10 @@ vgm_c_debugMenuEH = [true, "OnGameInterrupt", {
                 private _reasons = _unit getVariable "vgm_c_coefficient_currentCoefficients" get _coefficient apply {
                     [_x, _y#0, ["", "persistent"] select _y#1] joinString " "
                 };
-                _this lnbSetTooltip [[_row, 0], _reasons joinString endl];
+                private _overrides = _unit getVariable "vgm_c_coefficient_currentCoefficientsOverrides" get _coefficient apply {
+                    ["override", _x] joinString " "
+                };
+                _this lnbSetTooltip [[_row, 0], trim ([_reasons joinString endl, _overrides joinString endl] joinString endl)];
             } forEach vgm_c_coefficient_allCoefficients;
         }] call vgm_c_debugMenu_addSection;
 

--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -141,6 +141,7 @@ class vgm_c
         };
         class coefficient_remove {};
         class coefficient_set {};
+        class coefficient_unitInit {};
     };
 
     class displays

--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -131,6 +131,7 @@ class vgm_c
 
         class coefficient_create {};
         class coefficient_get {};
+        class coefficient_override {};
         class coefficient_postInit
         {
             postInit = 1;


### PR DESCRIPTION
- title

Allows us to temporarily override/pause the coefficient system callbacks while still allowing to change the coefficient reasons/values. This allows us to for example set the value of `setAnimSpeedCoef` for the duration of the item apply animation.

Needed for medical anims and drag/carry.