### PR TITLE
Adds compiler, basic nodes and basic test to behaviour trees

### DIFF
--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -53,6 +53,28 @@ class vgm_g
         };
     };
 
+    class behaviour_trees_compiler
+    {
+        VGM_GLOBAL_PATH(\systems\behaviour_trees\compiler\global);
+        class btree_compileTree {};
+        class btree_runBasicTest {};
+    };
+
+    class behaviour_trees_nodes
+    {
+        VGM_GLOBAL_PATH(\systems\behaviour_trees\nodes\global);
+
+        /* Template nodes / base nodes */
+        class btree_action_basic {};
+        class btree_composite_selector {};
+        class btree_composite_sequence {};
+        class btree_decorator_basic {};
+
+        /* Custom nodes */
+        class btree_decorator_alwaysFail {};
+        class btree_decorator_alwaysSucceed {};
+    };
+
     class behaviour_trees_runner
     {
         VGM_GLOBAL_PATH(\systems\behaviour_trees\runner\global);

--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -69,10 +69,12 @@ class vgm_g
         class btree_composite_selector {};
         class btree_composite_sequence {};
         class btree_decorator_basic {};
+        class btree_decorator_basicService {};
 
         /* Custom nodes */
         class btree_decorator_alwaysFail {};
         class btree_decorator_alwaysSucceed {};
+        class btree_decorator_loopInfinitely {};
     };
 
     class behaviour_trees_runner

--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -88,6 +88,9 @@ class vgm_g
         class btree_abort_selector {};
         class btree_abort_sequence {};
 
+        class btree_callOnTreeAssignedCallbacks {};
+        class btree_callOnTreeUnassignedCallbacks {};
+
         class btree_childFinished_action {};
         class btree_childFinished_decorator {};
         class btree_childFinished_selector {};

--- a/game/functions/systems/behaviour_trees/behaviour_trees.inc
+++ b/game/functions/systems/behaviour_trees/behaviour_trees.inc
@@ -19,6 +19,6 @@
 #define ACTION_RUN_CURRENT_NODE vgm_g_fnc_btree_runCurrentNode
 #define ACTION_PANIC vgm_g_fnc_btree_panic
 
-#define NO_NEXT_ACTION [[], {}]
+#define NO_ACTION_UNTIL_NEXT_TICK [[], {}]
 
 #endif

--- a/game/functions/systems/behaviour_trees/compiler/definitions.inc
+++ b/game/functions/systems/behaviour_trees/compiler/definitions.inc
@@ -1,5 +1,11 @@
+#ifdef VGM_BEHAVIOUR_TREES_COMPILER
+#else
+#define VGM_BEHAVIOUR_TREES_COMPILER
+
 #define SELECTOR vgm_g_fnc_btree_composite_selector
 #define SEQUENCE vgm_g_fnc_btree_composite_sequence
 #define CONDITION( NAME ) vgm_g_fnc_btree_condition_##NAME
 #define ACTION( NAME ) vgm_g_fnc_btree_action_##NAME
 #define DECORATOR( NAME ) vgm_g_fnc_btree_decorator_##NAME
+
+#endif

--- a/game/functions/systems/behaviour_trees/compiler/definitions.inc
+++ b/game/functions/systems/behaviour_trees/compiler/definitions.inc
@@ -1,0 +1,5 @@
+#define SELECTOR vgm_g_fnc_btree_composite_selector
+#define SEQUENCE vgm_g_fnc_btree_composite_sequence
+#define CONDITION( NAME ) vgm_g_fnc_btree_condition_##NAME
+#define ACTION( NAME ) vgm_g_fnc_btree_action_##NAME
+#define DECORATOR( NAME ) vgm_g_fnc_btree_decorator_##NAME

--- a/game/functions/systems/behaviour_trees/compiler/global/TestTree.sqf
+++ b/game/functions/systems/behaviour_trees/compiler/global/TestTree.sqf
@@ -1,0 +1,72 @@
+tree =createHashMapFromArray [
+	["type", "sequence"],
+	["name", "testsequence"],
+	["children", [
+		createHashMapFromArray [
+			["type", "action"],
+			["name", "testaction1"],
+			["onEnter", { ["running"] }],
+			["onTick", { ["succeeded"] }],
+			["onExit", {}]
+		],
+		createHashMapFromArray [
+			["type", "selector"],
+			["name", "testselector"],
+			["children", [
+				createHashMapFromArray [
+					["type", "decorator"],
+					["name", "testdecorator"],
+					["condition", {!isNil "treepass"}],
+					["onEnter", {["running"]}],
+					["abortLowerPriority", true],
+					["onChildFinished", { _this # 2 }],
+					["onExit", {}],
+					["children", [
+						createHashMapFromArray [
+							["type", "action"],
+							["name", "testaction4"],
+							["onEnter", { ["running"] }],
+							["onTick", { ["succeeded"] }],
+							["onExit", {}]
+						]
+					]]
+				],
+				createHashMapFromArray [
+					["type", "action"],
+					["name", "testaction3"],
+					["onEnter", { ["running"] }],
+					["onTick", { ["running"] }],
+					["onExit", {}]
+				]
+			]]
+		],
+		createHashMapFromArray [
+			["type", "decorator"],
+			["name", "testdecorator"],
+			["onEnter", { ["failed"] }],
+			["onChildFinished", { _this }],
+			["onExit", {}],
+			["children", [
+				createHashMapFromArray [
+					["type", "action"],
+					["name", "testaction4"],
+					["onEnter", { ["running"] }],
+					["onTick", { ["succeeded"] }],
+					["onExit", {}]
+				]
+			]]
+		],
+		createHashMapFromArray [
+			["type", "action"],
+			["name", "testaction5"],
+			["onEnter", { ["running"] }],
+			["onTick", { ["succeeded"] }],
+			["onExit", {}]
+		]
+	]]
+
+]
+
+
+
+

--- a/game/functions/systems/behaviour_trees/compiler/global/fn_btree_compileTree.sqf
+++ b/game/functions/systems/behaviour_trees/compiler/global/fn_btree_compileTree.sqf
@@ -2,7 +2,7 @@
     File: fn_btree_compileTree.sqf
     Author: Savage Game Design
     Date: 2024-01-26
-    Last Update: 2024-02-02
+    Last Update: 2024-02-03
     Public: No
 
     Description:
@@ -19,6 +19,10 @@
 
 params ["_tree"];
 
+// Hashmaps prevent identical code running multiple times.
+private _extern_onTreeAssignedCallbacks = createHashMap;
+private _extern_onTreeUnassignedCallbacks = createHashMap;
+
 // Recursive algorithm should be fine, as our behaviour trees are unlikely to ever be more than 10 nodes deep.
 private _fnc_compileNode = {
     params ["_constructor", "_params", "_children"];
@@ -26,7 +30,22 @@ private _fnc_compileNode = {
     private _childNodes = _children apply {_x call _fnc_compileNode};
 
     // By passing built children to the constructor, we enable the constructor to modify them as needed.
-    [createHashMapFromArray _params, _childNodes] call _constructor
+    private _node = [createHashMapFromArray _params, _childNodes] call _constructor;
+
+    if ("onTreeAssigned" in _node) then {
+        _extern_onTreeAssignedCallbacks set [_node get "onTreeAssigned", true];
+    };
+
+    if ("onTreeUnassigned" in _node) then {
+        _extern_onTreeUnassignedCallbacks set [_node get "onTreeUnassigned", true];
+    };
+
+    _node
 };
 
-_tree call _fnc_compileNode
+createHashMapFromArray [
+    ["rootNode", _tree call _fnc_compileNode],
+    ["onTreeAssignedCallbacks", keys _extern_onTreeAssignedCallbacks],
+    ["onTreeUnassignedCallbacks", keys _extern_onTreeUnassignedCallbacks]
+]
+

--- a/game/functions/systems/behaviour_trees/compiler/global/fn_btree_compileTree.sqf
+++ b/game/functions/systems/behaviour_trees/compiler/global/fn_btree_compileTree.sqf
@@ -1,0 +1,32 @@
+/*
+    File: fn_btree_compileTree.sqf
+    Author: Savage Game Design
+    Date: 2024-01-26
+    Last Update: 2024-02-02
+    Public: No
+
+    Description:
+        Compiles a runnable behaviour tree, from a behaviour tree in array format.
+
+    Parameter(s):
+        _tree - Behaviour tree [ARRAY]
+
+    Returns:
+        A compiled behaviour tree, ready for assigning to a group and running [HASHMAP]
+
+    Example(s):
+ */
+
+params ["_tree"];
+
+// Recursive algorithm should be fine, as our behaviour trees are unlikely to ever be more than 10 nodes deep.
+private _fnc_compileNode = {
+    params ["_constructor", "_params", "_children"];
+
+    private _childNodes = _children apply {_x call _fnc_compileNode};
+
+    // By passing built children to the constructor, we enable the constructor to modify them as needed.
+    [createHashMapFromArray _params, _childNodes] call _constructor
+};
+
+_tree call _fnc_compileNode

--- a/game/functions/systems/behaviour_trees/compiler/global/fn_btree_runBasicTest.sqf
+++ b/game/functions/systems/behaviour_trees/compiler/global/fn_btree_runBasicTest.sqf
@@ -74,7 +74,7 @@ private _testGroup = createGroup civilian;
 [_testGroup] call vgm_g_fnc_btree_tickGroup;
 
 // Change the tree so the UnassignTree callbacks get called.
-private _alternateTree = [ACTION(basic), []] call vgm_g_fnc_btree_compileTree;
+private _alternateTree = [[ACTION(basic), []]] call vgm_g_fnc_btree_compileTree;
 [_testGroup, _alternateTree] call vgm_g_fnc_btree_setTree;
 
 private _result = createHashMap;

--- a/game/functions/systems/behaviour_trees/compiler/global/fn_btree_runBasicTest.sqf
+++ b/game/functions/systems/behaviour_trees/compiler/global/fn_btree_runBasicTest.sqf
@@ -4,7 +4,7 @@
     File: fn_btree_runBasicTest.sqf
     Author: Savage Game Design
     Date: 2024-01-26
-    Last Update: 2024-02-02
+    Last Update: 2024-02-03
     Public: Yes
 
     Description:
@@ -18,6 +18,26 @@
     Example(s):
         [] call vgm_g_fnc_btree_runBasicTest;
  */
+
+private _extern_treeAssignedCalled = false;
+private _extern_treeUnassignedCalled = false;
+
+private _testTreeAssignmentNode = {
+    params ["_params", "_children"];
+
+    private _action = _this call vgm_g_fnc_btree_action_basic;
+    _action set ["onTreeAssigned", {
+        params ["_group"];
+        _extern_treeAssignedCalled = true;
+    }];
+
+    _action set ["onTreeUnassigned", {
+        params ["_group"];
+        _extern_treeUnassignedCalled = true;
+    }];
+
+    _action
+};
 
 private _exampleTree =
 [DECORATOR(basicService), [], [
@@ -38,7 +58,8 @@ private _exampleTree =
         // Allows testing service and interrupt behaviour.
         [DECORATOR(loopInfinitely), [], [
             [ACTION(basic), []]
-        ]]
+        ]],
+        [_testTreeAssignmentNode, []]
     ]]
 ]]
 ;
@@ -52,7 +73,17 @@ private _testGroup = createGroup civilian;
 [_testGroup] call vgm_g_fnc_btree_tickGroup;
 [_testGroup] call vgm_g_fnc_btree_tickGroup;
 
-[
-    _compiledTree,
-    _testGroup
-]
+// Change the tree so the UnassignTree callbacks get called.
+private _alternateTree = [ACTION(basic), []] call vgm_g_fnc_btree_compileTree;
+[_testGroup, _alternateTree] call vgm_g_fnc_btree_setTree;
+
+private _result = createHashMap;
+
+_result set ["onTreeAssignedCalled", _extern_treeAssignedCalled];
+_result set ["onTreeUnassignedCalled", _extern_treeUnassignedCalled];
+_result set ["log", (_group getVariable "vgm_l_btree_log") joinString endl];
+_result set ["compiledTree", _compiledTree];
+
+deleteGroup _testGroup;
+
+_result

--- a/game/functions/systems/behaviour_trees/compiler/global/fn_btree_runBasicTest.sqf
+++ b/game/functions/systems/behaviour_trees/compiler/global/fn_btree_runBasicTest.sqf
@@ -1,0 +1,48 @@
+#include "..\definitions.inc"
+#include "..\..\behaviour_trees.inc"
+/*
+    File: fn_btree_runBasicTest.sqf
+    Author: Savage Game Design
+    Date: 2024-01-26
+    Last Update: 2024-02-02
+    Public: Yes
+
+    Description:
+        Performs a basic test of the behaviour tree system.
+
+    Parameter(s):
+        None
+
+    Returns:
+
+    Example(s):
+        [] call vgm_g_fnc_btree_runBasicTest;
+ */
+
+private _exampleTree =
+[SELECTOR, [["name", "root selector"]], [
+    [DECORATOR(basic), [], [
+        [ACTION(basic), []]
+    ]],
+    [ACTION(basic), []],
+    [SEQUENCE, [["name", "dont execute last child"]], [
+        [ACTION(basic), []],
+        [DECORATOR(alwaysFail), [], [
+            [ACTION(basic), []]
+        ]],
+        [ACTION(basic), [["name", "won't run"]]]
+    ]]
+]];
+
+private _compiledTree = [_exampleTree] call vgm_g_fnc_btree_compileTree;
+
+private _testGroup = createGroup civilian;
+
+[_testGroup, _compiledTree] call vgm_g_fnc_btree_setTree;
+
+[_testGroup] call vgm_g_fnc_btree_tickGroup;
+
+[
+    _compiledTree,
+    _testGroup
+]

--- a/game/functions/systems/behaviour_trees/compiler/global/fn_btree_runBasicTest.sqf
+++ b/game/functions/systems/behaviour_trees/compiler/global/fn_btree_runBasicTest.sqf
@@ -21,17 +21,19 @@
 
 private _exampleTree =
 [SELECTOR, [["name", "root selector"]], [
-    [DECORATOR(basic), [], [
-        [ACTION(basic), []]
+    [DECORATOR(alwaysFail), [], [
+        [DECORATOR(basic), [], [
+            [ACTION(basic), []]
+        ]]
     ]],
-    [ACTION(basic), []],
-    [SEQUENCE, [["name", "dont execute last child"]], [
+    [SEQUENCE, [["name", "fail before last child"]], [
         [ACTION(basic), []],
         [DECORATOR(alwaysFail), [], [
             [ACTION(basic), []]
         ]],
         [ACTION(basic), [["name", "won't run"]]]
-    ]]
+    ]],
+    [ACTION(basic), []]
 ]];
 
 private _compiledTree = [_exampleTree] call vgm_g_fnc_btree_compileTree;

--- a/game/functions/systems/behaviour_trees/compiler/global/fn_btree_runBasicTest.sqf
+++ b/game/functions/systems/behaviour_trees/compiler/global/fn_btree_runBasicTest.sqf
@@ -20,21 +20,28 @@
  */
 
 private _exampleTree =
-[SELECTOR, [["name", "root selector"]], [
-    [DECORATOR(alwaysFail), [], [
-        [DECORATOR(basic), [], [
+[DECORATOR(basicService), [], [
+    [SELECTOR, [["name", "root selector"]], [
+        [DECORATOR(alwaysFail), [], [
+            [DECORATOR(basic), [], [
+                [ACTION(basic), []]
+            ]]
+        ]],
+        [SEQUENCE, [["name", "fail before last child"]], [
+            [ACTION(basic), []],
+            [DECORATOR(alwaysFail), [], [
+                [ACTION(basic), []]
+            ]],
+            [ACTION(basic), [["name", "won't run"]]]
+        ]],
+        // Infinite loop means the tree doesn't ever return to root.
+        // Allows testing service and interrupt behaviour.
+        [DECORATOR(loopInfinitely), [], [
             [ACTION(basic), []]
         ]]
-    ]],
-    [SEQUENCE, [["name", "fail before last child"]], [
-        [ACTION(basic), []],
-        [DECORATOR(alwaysFail), [], [
-            [ACTION(basic), []]
-        ]],
-        [ACTION(basic), [["name", "won't run"]]]
-    ]],
-    [ACTION(basic), []]
-]];
+    ]]
+]]
+;
 
 private _compiledTree = [_exampleTree] call vgm_g_fnc_btree_compileTree;
 
@@ -42,6 +49,7 @@ private _testGroup = createGroup civilian;
 
 [_testGroup, _compiledTree] call vgm_g_fnc_btree_setTree;
 
+[_testGroup] call vgm_g_fnc_btree_tickGroup;
 [_testGroup] call vgm_g_fnc_btree_tickGroup;
 
 [

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_action_basic.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_action_basic.sqf
@@ -1,0 +1,47 @@
+#include "..\..\behaviour_trees.inc"
+/*
+    File: fn_btree_action_basic.sqf
+    Author:
+    Date: 2024-02-02
+    Last Update: 2024-02-02
+    Public: No
+
+    Description:
+        Action node.
+        Performs some action, possibly over multiple ticks of the tree.
+
+        Cannot have any children.
+
+        "onEnter" is called when the node is first visited.
+        "onTick" is executed every tick, but will not run unless "onEnter" returns RESULT_RUNNING
+        "onExit" is always called to clean up the node, including if the action is aborted.
+
+    Parameter(s):
+        _params - Any parameters accepted by the node. [HASHMAP]
+        _children - Node's children (should always be empty for actions) [ARRAY]
+
+    Returns:
+        Generic action node [HASHMAP]
+
+    Example(s):
+        [] call vgm_g_fnc_btree_action_basic;
+ */
+
+params ["_params", "_children"];
+
+createHashMapFromArray [
+    ["type", NODE_TYPE_ACTION],
+    ["name", _params getOrDefault ["name", "generic action"]],
+    ["onEnter", {
+        params ["_node", "_state"];
+        [ RESULT_RUNNING ]
+    }],
+    ["onTick", {
+        params ["_node", "_sttate"];
+        [ RESULT_SUCCEEDED ]
+    }],
+    ["onExit", {
+        params ["_node", "_state", "_result"];
+        // Cleanup only, no return value.
+    }]
+]

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_action_basic.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_action_basic.sqf
@@ -3,7 +3,7 @@
     File: fn_btree_action_basic.sqf
     Author:
     Date: 2024-02-02
-    Last Update: 2024-02-02
+    Last Update: 2024-02-03
     Public: No
 
     Description:
@@ -15,6 +15,9 @@
         "onEnter" is called when the node is first visited.
         "onTick" is executed every tick, but will not run unless "onEnter" returns RESULT_RUNNING
         "onExit" is always called to clean up the node, including if the action is aborted.
+
+        "onTreeAssigned" is called when the tree is assigned to a group, and is useful for setting up event handlers.
+        "onTreeUnassigned" is called when the tree is unassigned from the group or the group is deleted, and is useful for cleaning up event handlers.
 
     Parameter(s):
         _params - Any parameters accepted by the node. [HASHMAP]

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_composite_selector.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_composite_selector.sqf
@@ -1,0 +1,38 @@
+#include "..\..\behaviour_trees.inc"
+/*
+    File: fn_btree_composite_selector.sqf
+    Author:
+    Date: 2024-02-02
+    Last Update: 2024-02-02
+    Public: Yes
+
+    Description:
+        Standard selector node. Runs children in order until one succeeds.
+
+        If a child is currently running, and a previous child decorator becomes runnable,
+        the currently running child can be interrupted and execution can jump to the previous
+        decorator.
+
+        I.e, earlier children can take priority over currently executing later children.
+
+        See "abortLowerPriority" on decorator nodes.
+
+    Parameter(s):
+        _params - Any parameters accepted by the node. [HASHMAP]
+        _children - Node's children [ARRAY]
+
+    Returns:
+        Behaviour tree selector node [HASHMAP]
+
+    Example(s):
+        [] call vgm_g_fnc_btree_composite_selector;
+ */
+
+params ["_params", "_children"];
+
+createHashMapFromArray [
+    ["type", NODE_TYPE_SELECTOR],
+    ["name", _params getOrDefault ["name", "selector"] ],
+    ["children", _children]
+]
+

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_composite_sequence.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_composite_sequence.sqf
@@ -1,0 +1,29 @@
+#include "..\..\behaviour_trees.inc"
+/*
+    File: fn_btree_composite_sequence.sqf
+    Author: Savage Game Design
+    Date: 2024-02-02
+    Last Update: 2024-02-02
+    Public: Yes
+
+    Description:
+        Standard sequence node. Runs children in order until one fails.
+
+    Parameter(s):
+        _params - Any parameters accepted by the node. [HASHMAP]
+        _children - Node's children [ARRAY]
+
+    Returns:
+        Selector behaviour tree node [HASHMAP]
+
+    Example(s):
+        [] call vgm_g_fnc_btree_composite_sequence;
+ */
+
+params ["_params", "_children"];
+
+createHashMapFromArray [
+    ["type", NODE_TYPE_SEQUENCE],
+    ["name", _params getOrDefault ["name", "sequence"]],
+    ["children", _children]
+]

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_alwaysFail.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_alwaysFail.sqf
@@ -1,0 +1,38 @@
+#include "..\..\behaviour_trees.inc"
+/*
+    File: fn_btree_decorator_alwaysFail.sqf
+    Author: Savage Game Design
+    Date: 2024-02-02
+    Last Update: 2024-02-02
+    Public: Yes
+
+    Description:
+        Decorator node.
+
+        Runs the child, but always returns failure after the child completes.
+
+        Note: Will still return RESULT_ABORTED if aborted.
+
+    Parameter(s):
+        _params - Any parameters accepted by the node. [HASHMAP]
+        _children - Node's children (should always be exactly 1 node) [ARRAY]
+
+    Returns:
+        Decorator behaviour tree node [HASHMAP]
+
+    Example(s):
+        [] call vgm_g_fnc_btree_decorator_alwaysFail;
+ */
+
+params ["_params", "_children"];
+
+private _decorator = _this call vgm_g_fnc_btree_decorator_basic;
+
+_decorator set ["name", "always fail"];
+
+_decorator set ["onChildFinished", {
+    params ["_node", "_state", "_childResult"];
+    [ RESULT_FAILED ]
+}];
+
+_decorator

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_alwaysSucceed.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_alwaysSucceed.sqf
@@ -1,0 +1,38 @@
+#include "..\..\behaviour_trees.inc"
+/*
+    File: fn_btree_decorator_alwaysSucceed.sqf
+    Author: Savage Game Design
+    Date: 2024-02-02
+    Last Update: 2024-02-02
+    Public: Yes
+
+    Description:
+        Decorator node.
+
+        Runs the child, but always returns success after the child completes.
+
+        Note: Will still return RESULT_ABORTED if aborted.
+
+    Parameter(s):
+        _params - Any parameters accepted by the node. [HASHMAP]
+        _children - Node's children (should always be exactly 1 node) [ARRAY]
+
+    Returns:
+        Decorator behaviour tree node [HASHMAP]
+
+    Example(s):
+        [] call vgm_g_fnc_btree_decorator_alwaysSucceed;
+ */
+
+params ["_params", "_children"];
+
+private _decorator = _this call vgm_g_fnc_btree_decorator_basic;
+
+_decorator set ["name", "always succeed"];
+
+_decorator set ["onChildFinished", {
+    params ["_node", "_state", "_childResult"];
+    [ RESULT_SUCCEEDED ]
+}];
+
+_decorator

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_basic.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_basic.sqf
@@ -11,15 +11,31 @@
         Allows a single child node to be run conditionally,
         or for other effects to be triggered before the child node runs.
 
-        "abortLowerPriority" can be used when a decorator is a child of a selector,
-        making control flow jump to this decorator if it becomes runnable.
+        "condition"
+            - Called to check if the node can be entered.
 
-        In practice, this means "condition" is checked every tick when "abortLowerPriority" is set,
-        so be wary of running performance intensive code in the condition.
+        "onEnter"
+            - Fires when the condition succeeds and the node is entered.
+            - Should return "RUNNING" to start execution of the child, any other result prevents the child being run.
 
-        "onChildFinished" can return RESULT_RUNNING to re-run the child, or otherwise modify the child's result.
+        "onChildFinished"
+            - Called when the child node returns.
+            - Can return RESULT_RUNNING to re-run the child, or otherwise modify the child's result.
 
-        "onEnter" should return "RUNNING" to start execution of the child, any other result prevents the child being run.
+        "onExit"
+            - Called to clean up the node
+            - Return value is ignored
+
+        "abortLowerPriority"
+            - Can be used when a decorator is a child of a selector,
+              making control flow jump to this decorator if it becomes runnable.
+
+        "abortChildrenOnConditionFailure"
+            - If true, immediately stop all child nodes if the condition starts failing.
+
+        "isService"
+            - If true, run the "onTick" code every tick, while this decorator is running
+              (i.e, any children are running)
 
     Parameter(s):
         _params - Any parameters accepted by the node. [HASHMAP]
@@ -37,7 +53,9 @@ params ["_params", "_children"];
 createHashMapFromArray [
     ["type", NODE_TYPE_DECORATOR],
     ["name", _params getOrDefault ["name", "basic decorator"]],
-    ["abortLowerPriority", _params get ["abortLowerPriority", false]],
+    ["abortLowerPriority", _params getOrDefault ["abortLowerPriority", false]],
+    ["abortChildrenOnConditionFailure", _params getOrDefault ["abortChildrenOnConditionFailure", false]],
+    ["isService", false],
     ["condition", {
         params ["_node"];
         // Always run
@@ -48,6 +66,7 @@ createHashMapFromArray [
         // Execute the child
         [RESULT_RUNNING]
     }],
+    ["onTick", {}],
     ["onChildFinished", {
         params ["_node", "_state", "_childResult"];
         // Preserve child's result

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_basic.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_basic.sqf
@@ -3,7 +3,7 @@
     File: fn_btree_decorator_basic.sqf
     Author: Savage Game Design
     Date: 2024-02-02
-    Last Update: 2024-02-02
+    Last Update: 2024-02-03
     Public: Yes
 
     Description:
@@ -36,6 +36,14 @@
         "isService"
             - If true, run the "onTick" code every tick, while this decorator is running
               (i.e, any children are running)
+
+        "onTreeAssigned"
+            - Called when the tree is assigned to a group
+            - Useful for setting up event handlers.
+
+        "onTreeUnassigned"
+            - Called when the tree is unassigned from the group or the group is deleted
+            - Useful for cleaning up event handlers.
 
     Parameter(s):
         _params - Any parameters accepted by the node. [HASHMAP]

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_basic.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_basic.sqf
@@ -1,0 +1,62 @@
+#include "..\..\behaviour_trees.inc"
+/*
+    File: fn_btree_decorator_basic.sqf
+    Author: Savage Game Design
+    Date: 2024-02-02
+    Last Update: 2024-02-02
+    Public: Yes
+
+    Description:
+        Decorator node.
+        Allows a single child node to be run conditionally,
+        or for other effects to be triggered before the child node runs.
+
+        "abortLowerPriority" can be used when a decorator is a child of a selector,
+        making control flow jump to this decorator if it becomes runnable.
+
+        In practice, this means "condition" is checked every tick when "abortLowerPriority" is set,
+        so be wary of running performance intensive code in the condition.
+
+        "onChildFinished" can return RESULT_RUNNING to re-run the child, or otherwise modify the child's result.
+
+        "onEnter" should return "RUNNING" to start execution of the child, any other result prevents the child being run.
+
+    Parameter(s):
+        _params - Any parameters accepted by the node. [HASHMAP]
+        _children - Node's children (should always be exactly 1 node) [ARRAY]
+
+    Returns:
+        Basic decorator behaviour tree node [HASHMAP]
+
+    Example(s):
+        [] call vgm_g_fnc_btree_decorator_basic;
+ */
+
+params ["_params", "_children"];
+
+createHashMapFromArray [
+    ["type", NODE_TYPE_DECORATOR],
+    ["name", _params getOrDefault ["name", "basic decorator"]],
+    ["abortLowerPriority", _params get ["abortLowerPriority", false]],
+    ["condition", {
+        params ["_node"];
+        // Always run
+        true
+    }],
+    ["onEnter", {
+        params ["_node"];
+        // Execute the child
+        [RESULT_RUNNING]
+    }],
+    ["onChildFinished", {
+        params ["_node", "_state", "_childResult"];
+        // Preserve child's result
+        [ _childResult ]
+    }],
+    ["onExit", {
+        params ["_node", "_state", "_result"];
+        // Used for cleanup, no return value.
+    }],
+    // Ensure we only ever have one child
+    ["children", [ _children # 0 ]]
+]

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_basic.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_basic.sqf
@@ -62,7 +62,7 @@ createHashMapFromArray [
         true
     }],
     ["onEnter", {
-        params ["_node"];
+        params ["_node", "_state"];
         // Execute the child
         [RESULT_RUNNING]
     }],

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_basicService.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_basicService.sqf
@@ -1,0 +1,44 @@
+#include "..\..\behaviour_trees.inc"
+/*
+    File: fn_btree_decorator_basicService.sqf
+    Author: Savage Game Design
+    Date: 2024-02-02
+    Last Update: 2024-02-02
+    Public: Yes
+
+    Description:
+        Decorator node (see basic decorator for more info).
+
+        Simple service node, runs the onTick code whenever its in the stack, and whenever its entered.
+
+        Used as a base for other nodes, or debugging.
+
+    Parameter(s):
+        _params - Any parameters accepted by the node. [HASHMAP]
+        _children - Node's children (should always be exactly 1 node) [ARRAY]
+
+    Returns:
+        Decorator behaviour tree node [HASHMAP]
+
+    Example(s):
+        [] call vgm_g_fnc_btree_decorator_basicService;
+ */
+
+params ["_params", "_children"];
+
+private _decorator = _this call vgm_g_fnc_btree_decorator_basic;
+
+_decorator set ["name", "basic service"];
+_decorator set ["isService", true];
+_decorator set ["onEnter", {
+    params ["_node", "_state"];
+
+    _this call (_node get "onTick");
+
+    [ RESULT_RUNNING ]
+}];
+_decorator set ["onTick", {
+    ["Basic service node executed"] call vgm_g_fnc_btree_log;
+}];
+
+_decorator

--- a/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_loopInfinitely.sqf
+++ b/game/functions/systems/behaviour_trees/nodes/global/fn_btree_decorator_loopInfinitely.sqf
@@ -1,0 +1,35 @@
+#include "..\..\behaviour_trees.inc"
+/*
+    File: fn_btree_decorator_loopInfinite.sqf
+    Author: Savage Game Design
+    Date: 2024-02-02
+    Last Update: 2024-02-02
+    Public: Yes
+
+    Description:
+        Decorator node (see basic decorator for more info).
+
+        Loops the child node infinitely until aborted.
+
+    Parameter(s):
+        _params - Any parameters accepted by the node. [HASHMAP]
+        _children - Node's children (should always be exactly 1 node) [ARRAY]
+
+    Returns:
+        Decorator behaviour tree node [HASHMAP]
+
+    Example(s):
+        [] call vgm_g_fnc_btree_decorator_loopInfinitely;
+ */
+
+params ["_params", "_children"];
+
+private _decorator = _this call vgm_g_fnc_btree_decorator_basic;
+
+_decorator set ["name", "loop infinitely"];
+_decorator set ["onChildFinished", {
+    params ["_node", "_state", "_childResult"];
+    [ RESULT_RUNNING ]
+}];
+
+_decorator

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_callOnTreeAssignedCallbacks.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_callOnTreeAssignedCallbacks.sqf
@@ -1,0 +1,36 @@
+/*
+    File: fn_btree_callOnTreeAssignedCallbacks.sqf
+    Author: Savage Game Design
+    Date: 2024-02-03
+    Last Update: 2024-02-03
+    Public: No
+
+    Description:
+        Nodes can register code to be run when the tree is assigned to a group.
+        This allows them to do things like set up event handlers.
+
+        This function runs that code, and makes sure it's tidied up if the group is deleted.
+
+    Parameter(s):
+        _group - Group with an assigned tree [GROUP]
+
+    Returns:
+        Nothing
+
+    Example(s):
+        [_myGroup] call vgm_g_fnc_btree_callOnTreeAssignedCallbacks;
+ */
+
+params ["_group"];
+
+private _tree = _group getVariable "vgm_l_btree_current";
+
+{
+    [_group] call _x;
+} forEach (_tree get "onTreeAssignedCallbacks");
+
+_group setVariable ["vgm_l_btree_onTreeUnassignedEventHandler", _group addEventHandler ["Deleted", {
+    params ["_group"];
+
+    [_group] call vgm_g_fnc_btree_callOnTreeUnassignedCallbacks;
+}]];

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_callOnTreeUnassignedCallbacks.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_callOnTreeUnassignedCallbacks.sqf
@@ -1,0 +1,32 @@
+/*
+    File: fn_btree_callOnTreeUnssignedCallbacks.sqf
+    Author: Savage Game Design
+    Date: 2024-02-03
+    Last Update: 2024-02-03
+    Public: No
+
+    Description:
+        Nodes can register code to be run when the tree is unassigned from a group, or the group is deleted.
+        This allows them to do things like clean up event handlers.
+
+        This function runs that code.
+
+    Parameter(s):
+        _group - Group with an assigned tree [GROUP]
+
+    Returns:
+        Nothing
+
+    Example(s):
+        [_myGroup] call vgm_g_fnc_btree_callOnTreeAssignedCallbacks;
+ */
+
+params ["_group"];
+
+private _tree = _group getVariable "vgm_l_btree_current";
+
+{
+    [_group] call _x;
+} forEach (_tree get "onTreeUnassignedCallbacks");
+
+_group removeEventHandler ["Deleted", _group getVariable "vgm_l_btree_onTreeUnassignedEventHandler"];

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_childFinished_decorator.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_childFinished_decorator.sqf
@@ -33,7 +33,8 @@ private _result = [_node, _state, _childResult] call (_node get "onChildFinished
 _result params ["_statusCode"];
 
 if (_statusCode isEqualTo RESULT_RUNNING) exitWith {
-    [[0], ACTION_RUN_CHILD]
+    [format ["Re-running child of decorator (%1) next tick", _node get "name"]] call vgm_g_fnc_btree_log;
+    NO_ACTION_UNTIL_NEXT_TICK
 };
 
 [[_statusCode], ACTION_RETURN_TO_PARENT]

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_childFinished_decorator.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_childFinished_decorator.sqf
@@ -36,4 +36,4 @@ if (_statusCode isEqualTo RESULT_RUNNING) exitWith {
     [[0], ACTION_RUN_CHILD]
 };
 
-[[_childResult], ACTION_RETURN_TO_PARENT]
+[[_statusCode], ACTION_RETURN_TO_PARENT]

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_enterNode_decorator.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_enterNode_decorator.sqf
@@ -24,13 +24,14 @@
 params ["_stackFrame"];
 
 private _node = _stackFrame get "node";
+private _state = _stackFrame get "state";
 
 private _conditionResult = [_node] call (_node get "condition");
 if (!_conditionResult) exitWith {
     [[RESULT_FAILED], ACTION_RETURN_TO_PARENT]
 };
 
-private _enterResult = [_node] call (_node get "onEnter");
+private _enterResult = [_node, _state] call (_node get "onEnter");
 _enterResult params ["_statusCode"];
 
 if (_statusCode isEqualTo RESULT_RUNNING) exitWith {

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_enterNode_decorator.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_enterNode_decorator.sqf
@@ -36,7 +36,6 @@ _enterResult params ["_statusCode"];
 if (_statusCode isEqualTo RESULT_RUNNING) exitWith {
     _stackFrame set ["isInterruptNode", _node get "abortChildrenOnConditionFailure"];
     _stackFrame set ["isServiceNode", _node get "isService"];
-    // TODO: Services stack
 
     [[0], ACTION_RUN_CHILD]
 };

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_panic.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_panic.sqf
@@ -32,4 +32,4 @@ private _formattedMessage = format ["BEHAVIOUR TREE PANIC: %1", _message];
 // Reset the stack to make the behaviour tree start executing from the beginning.
 _extern_btreeState set ["stack", []];
 
-NO_NEXT_ACTION
+NO_ACTION_UNTIL_NEXT_TICK

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_returnToParent.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_returnToParent.sqf
@@ -45,7 +45,7 @@ _extern_stack deleteAt _currentStackIndex;
 
 if (count _extern_stack == 0) exitWith {
     [format ["Return from root node, suspending execution until next tick"]] call vgm_g_fnc_btree_log;
-    NO_NEXT_ACTION
+    NO_ACTION_UNTIL_NEXT_TICK
 };
 
 private _parentStackItem = (_extern_stack # (_currentStackIndex - 1));

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_runCurrentNode_action.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_runCurrentNode_action.sqf
@@ -31,7 +31,7 @@ private _result = [_node, _state] call (_node get "onTick");
 private _statusCode = _result # 0;
 
 if (_statusCode isEqualTo RESULT_RUNNING) exitWith {
-    NO_NEXT_ACTION
+    NO_ACTION_UNTIL_NEXT_TICK
 };
 
 [[_statusCode], ACTION_RETURN_TO_PARENT]

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_runCurrentNode_decorator.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_runCurrentNode_decorator.sqf
@@ -24,8 +24,5 @@
 
 params ["_stackFrame"];
 
-// Bad case, shouldn't happen.
-["Cannot run current node - Decorator nodes should never be current"] call vgm_g_fnc_btree_log;
-
-// Return to parent, to try and recover.
-[[], ACTION_RETURN_TO_PARENT]
+// If decorator is current node, it's waiting to run the child again.
+[[0], ACTION_RUN_CHILD]

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_setTree.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_setTree.sqf
@@ -2,7 +2,7 @@
     File: fn_btree_setTree.sqf
     Author:
     Date: 2023-12-17
-    Last Update: 2023-12-18
+    Last Update: 2024-02-03
     Public: Yes
 
     Description:
@@ -25,8 +25,14 @@ params ["_group", "_tree"];
 private _currentTree = _group getVariable "vgm_l_btree_current";
 
 if (!isNil "_currentTree" && { _currentTree isNotEqualTo _tree }) then {
-    // TODO - Make this function. Abort the full stack.
-	//[_group] call vgm_g_fnc_btree_abortCurrentTree;
+    private _extern_btreeState = _group getVariable "vgm_l_btree_state";
+    private _extern_stack = _extern_btreeState get "stack";
+
+    // Make sure all nodes are allowed to clean themselves up.
+    [-1] call vgm_g_fnc_btree_unwindStackUpToIndex;
+
+    // Allow nodes to cleanup anything they did when the tree was assigned.
+    [_group] call vgm_g_fnc_btree_callOnTreeUnassignedCallbacks;
 };
 
 _group setVariable ["vgm_l_btree_current", _tree];
@@ -36,4 +42,4 @@ _group setVariable ["vgm_l_btree_state", createHashMapFromArray [
 ]];
 _group setVariable ["vgm_l_btree_log", []];
 
-
+[_group] call vgm_g_fnc_btree_callOnTreeAssignedCallbacks;

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_tickGroup.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_tickGroup.sqf
@@ -3,7 +3,7 @@
     File: fn_btree_tickGroup.sqf
     Author: Savage Game Design
     Date: 2023-12-17
-    Last Update: 2024-02-02
+    Last Update: 2024-02-03
     Public: Yes
 
     Description:
@@ -41,7 +41,7 @@ private _nextActionParams = [];
 // If no current node, start tree execution from the top.
 if (count _extern_stack == 0) then {
     _nextAction = ACTION_ENTER_NODE;
-    _nextActionParams = [_tree];
+    _nextActionParams = [_tree get "rootNode"];
 };
 
 [format ["Ticking behaviour tree for group %1 at %2", str _group, serverTime]] call vgm_g_fnc_btree_log;

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_tickGroup.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_tickGroup.sqf
@@ -49,17 +49,18 @@ if (count _extern_stack == 0) then {
 {
     // Check if there's any conditions on the current path that can cause us to abort.
     private _frame = _x;
-    if (_frame get "isInterruptNode" && {[_frame get "node", _frame get "state"] call (_frame get "condition") isEqualTo RESULT_FAILED} ) exitWith {
+    private _node = _frame get "node";
+    private _state = _frame get "state";
+
+    if (_frame get "isInterruptNode" && {[_node, _state] call (_node get "condition") isEqualTo RESULT_FAILED} ) exitWith {
         [_forEachIndex] call vgm_g_fnc_btree_unwindStackUpToIndex;
         _nextAction = ACTION_RETURN_TO_PARENT;
         _nextActionParams = [RESULT_FAILED];
     };
 
-    // TODO - Service nodes
-
     // Check if there's any higher priority nodes registered, that need us to abort and switch to them.
     private _newChildToRunIndex = _frame getOrDefault ["higherPriorityNodes", []] findIf {
-        private _child = _frame get "node" get "children" select _x;
+        private _child = _node get "children" select _x;
         [_child get "node"] call (_child get "condition")
     };
 
@@ -68,6 +69,11 @@ if (count _extern_stack == 0) then {
         _nextAction = ACTION_RUN_CHILD;
         _nextActionParams = [_frame get "higherPriorityNodes" select _newChildToRunIndex];
     };
+
+    if (_frame get "isServiceNode") then {
+        [_node, _state] call (_node get "onTick");
+    };
+
 } forEach _extern_stack;
 
 // Each action can return the next action that needs executing.

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_tickGroup.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_tickGroup.sqf
@@ -53,6 +53,7 @@ if (count _extern_stack == 0) then {
     private _state = _frame get "state";
 
     if (_frame get "isInterruptNode" && {[_node, _state] call (_node get "condition") isEqualTo RESULT_FAILED} ) exitWith {
+        [format ["Interrupting node %1 (%2) (depth %3) due to failed condition", _node get "name", _node get "type", _forEachIndex]] call vgm_g_fnc_btree_log;
         [_forEachIndex] call vgm_g_fnc_btree_unwindStackUpToIndex;
         _nextAction = ACTION_RETURN_TO_PARENT;
         _nextActionParams = [RESULT_FAILED];
@@ -65,12 +66,14 @@ if (count _extern_stack == 0) then {
     };
 
     if (_newChildToRunIndex > -1) exitWith {
+        [format ["Higher priority child available for %1 (%2) (depth %3), aborting current child", _node get "name", _node get "type", _forEachIndex]] call vgm_g_fnc_btree_log;
         [_forEachIndex] call vgm_g_fnc_btree_unwindStackUpToIndex;
         _nextAction = ACTION_RUN_CHILD;
         _nextActionParams = [_frame get "higherPriorityNodes" select _newChildToRunIndex];
     };
 
     if (_frame get "isServiceNode") then {
+        [format ["Running service node: %1 (%2) (depth %3)", _node get "name", _node get "type", _forEachIndex]] call vgm_f_fnc_btree_log;
         [_node, _state] call (_node get "onTick");
     };
 

--- a/game/functions/systems/behaviour_trees/runner/global/fn_btree_tickGroup.sqf
+++ b/game/functions/systems/behaviour_trees/runner/global/fn_btree_tickGroup.sqf
@@ -73,7 +73,7 @@ if (count _extern_stack == 0) then {
     };
 
     if (_frame get "isServiceNode") then {
-        [format ["Running service node: %1 (%2) (depth %3)", _node get "name", _node get "type", _forEachIndex]] call vgm_f_fnc_btree_log;
+        [format ["Running service node: %1 (%2) (depth %3)", _node get "name", _node get "type", _forEachIndex]] call vgm_g_fnc_btree_log;
         [_node, _state] call (_node get "onTick");
     };
 


### PR DESCRIPTION
This PR includes:
- Compiler for the behaviour trees
- A (manually run) test case, with an example tree.
- Some fixes for decorators
- Support for services (i.e Nodes that keep running while they're in the stack)
- onTreeAssigned and onTreeUnassigned, to allow nodes to register event handlers.