### PR TITLE
Medical - Body Part UI Tweaks

### DIFF
--- a/game/configs/mission/ui/VGM_DisplayMedical.hpp
+++ b/game/configs/mission/ui/VGM_DisplayMedical.hpp
@@ -141,6 +141,7 @@ class VGM_DisplayMedical
             idc = VGM_IDC_DISPLAYMEDICAL_HEAD;
             text = "soldier_head.paa";
             onButtonClick = VGM_UIEH(selectPart,Medical);
+            colorActive[] = {0.8,0.8,0.8,1};
             x = DISPLAY_X + (0.5 * DISPLAY_W - 0.5 * HEAD_W) * VGM_GRID_W;
             y = DISPLAY_Y + (MARGIN) * VGM_GRID_H;
             w = HEAD_W * VGM_GRID_W;

--- a/game/functions/core/client/displays/fn_displayMedical.sqf
+++ b/game/functions/core/client/displays/fn_displayMedical.sqf
@@ -4,7 +4,7 @@
     File: fn_displayMedical.sqf
     Author: Savage Game Design
     Date: 2023-05-18
-    Last Update: 2023-12-03
+    Last Update: 2024-03-02
     Public: No
 
     Description:
@@ -146,8 +146,13 @@ switch _mode do {
             _x params ["_idc", "_bodyPart"];
             private _ctrl = _display displayCtrl _idc;
 
-            private _color = COLOR_ARR select ([MENU_TARGET, _bodyPart] call vgm_c_fnc_medical_getWound);
+            private _wound = [MENU_TARGET, _bodyPart] call vgm_c_fnc_medical_getWound;
+
+            private _color = COLOR_ARR select _wound;
             _ctrl ctrlSetTextColor (_color + [1]);
+
+            private _levelText = localize format ["STR_VGM_MEDICAL_UI_TRAUMA_%1", _wound];
+            _ctrl ctrlSetTooltip format [localize "STR_VGM_MEDICAL_UI_INJURIES", _levelText];
         } forEach [
             [VGM_IDC_DISPLAYMEDICAL_HEAD, BODY_PART_HEAD],
             [VGM_IDC_DISPLAYMEDICAL_ARMLEFT, BODY_PART_ARMS],


### PR DESCRIPTION
- Change body part focus color to static light grey instead of profile theme color
- Add tooltip with injury level to body part

![image](https://github.com/Savage-Game-Design/Across-the-Fence/assets/4293906/4b598f52-0d5b-408e-84f0-d072dd80a83b)
![image](https://github.com/Savage-Game-Design/Across-the-Fence/assets/4293906/cccd7faa-29ce-47ae-8617-e24c4873afc8)
