### PR TITLE
WIP: Para Cleanup - Do not delete bodies close to players

### DIFF
--- a/game/mission/para_server_init.sqf
+++ b/game/mission/para_server_init.sqf
@@ -60,6 +60,7 @@ diag_log "VGM: Initialising Cleanup Routine";
 [
     createHashmapFromArray [
         ["minPlayerDistance", ["cleanup_min_player_distance", 400] call BIS_fnc_getParamValue],
+        ["minPlayerBodyDistance", ["cleanup_min_player_body_distance", 150] call BIS_fnc_getParamValue],
         ["maxBodies", ["cleanup_max_bodies", 50] call BIS_fnc_getParamValue],
         ["cleanPlacedGear", ["cleanup_placed_gear", 1] call BIS_fnc_getParamValue > 0],
         ["placedGearCleanupTime", ["cleanup_placed_gear_lifetime", 300] call BIS_fnc_getParamValue],

--- a/paradigm/server/functions/cleanup/fn_cleanup_job.sqf
+++ b/paradigm/server/functions/cleanup/fn_cleanup_job.sqf
@@ -13,6 +13,9 @@
 	Example(s): none
 */
 
+#define CLEAN_MIN_DIST para_s_cleanup_minPlayerDistance
+#define CLEAN_BODY_MIN_DIST para_s_cleanup_minPlayerBodyDistance
+
 para_s_cleanup_items_delete_immediately = para_s_cleanup_items_delete_immediately - [objNull];
 
 // For every bucket that might have an item ready to be cleaned up
@@ -36,7 +39,7 @@ para_s_cleanup_items_delete_immediately append (_itemsPassingTimeCheck - _newRan
 
 private _inPlayerRange = [];
 {
-	_inPlayerRange append (para_s_cleanup_items_range_restricted inAreaArray [getPos _x, para_s_cleanup_minPlayerDistance, para_s_cleanup_minPlayerDistance]);
+	_inPlayerRange append (para_s_cleanup_items_range_restricted inAreaArray [_x, CLEAN_MIN_DIST, CLEAN_MIN_DIST]);
 } forEach allPlayers;
 
 private _canDelete = para_s_cleanup_items_range_restricted - _inPlayerRange;
@@ -45,8 +48,20 @@ para_s_cleanup_items_delete_immediately append _canDelete;
 
 private _deadBodyOverrun = count para_s_cleanup_items_bodies - para_s_cleanup_max_bodies;
 if (_deadBodyOverrun > 0) then {
-	para_s_cleanup_items_delete_immediately append (para_s_cleanup_items_bodies select [0, _deadBodyOverrun]);
-	para_s_cleanup_items_bodies deleteRange [0, _deadBodyOverrun];
+    private _deletedBodiesIndices = [];
+    {
+        if (count (allPlayers inAreaArray [_x, CLEAN_BODY_MIN_DIST, CLEAN_BODY_MIN_DIST]) > 0) then {continue};
+        if (count _deletedBodiesIndices >= _deadBodyOverrun) exitWith {};
+
+        _deletedBodiesIndices pushBack _forEachIndex;
+        para_s_cleanup_items_delete_immediately pushBack _x;
+    } forEach para_s_cleanup_items_bodies;
+
+    #if __GAME_VER_MIN__ >= 18
+	para_s_cleanup_items_bodies deleteAt _deletedBodiesIndices;
+    #else
+    {para_s_cleanup_items_bodies deleteAt _x} forEach _deletedBodiesIndices;
+    #endif
 };
 
 [] spawn {

--- a/paradigm/server/functions/cleanup/fn_cleanup_subsystem_init.sqf
+++ b/paradigm/server/functions/cleanup/fn_cleanup_subsystem_init.sqf
@@ -17,6 +17,7 @@
 params [["_params", createHashMap]];
 
 para_s_cleanup_minPlayerDistance = _params getOrDefault ["minPlayerDistance", 400];
+para_s_cleanup_minPlayerBodyDistance = _params getOrDefault ["minPlayerBodyDistance", 150];
 para_s_cleanup_max_bodies = _params getOrDefault ["maxBodies", 50];
 // Remove items placed on the ground by players
 para_s_cleanup_clean_placed_gear = _params getOrDefault ["cleanPlacedGear", true];


### PR DESCRIPTION
- title

Bodies near the players will be skipped, searches until it finds the bodies to clear or the array ended.