### PR TITLE
Squad UI - Always draw group leader on the map #VGM-677

### DIFF
--- a/game/functions/systems/skill/client/passives/support/fn_skill_passives_support_shepherd.sqf
+++ b/game/functions/systems/skill/client/passives/support/fn_skill_passives_support_shepherd.sqf
@@ -2,7 +2,7 @@
     File: fn_skill_passives_support_shepherd.sqf
     Author: Savage Game Design
     Date: 2023-10-08
-    Last Update: 2024-02-10
+    Last Update: 2024-07-04
     Public: No
 
     Description:
@@ -18,35 +18,6 @@
         true call vgm_c_fnc_skill_passives_support_shepherd
  */
 
-#define FONT_SIZE 0.042
-#define CTRL_MAP (findDisplay 12 displayCtrl 51)
-
 params ["_known"];
 
-if (!_known) exitWith {
-    CTRL_MAP ctrlRemoveEventHandler ["Draw", vgm_c_skill_passives_support_shepherd_drawEh];
-};
-
-vgm_c_skill_passives_support_shepherd_drawColor = playerSide call BIS_fnc_sideColor;
-
-[] spawn {
-    waitUntil {!isNull CTRL_MAP};
-
-    vgm_c_skill_passives_support_shepherd_drawEh = CTRL_MAP ctrlAddEventHandler ["Draw", {
-        params ["_ctrlMap"];
-
-        {
-            _ctrlMap drawIcon [
-                getText (configOf _x >> "icon"),
-                vgm_c_skill_passives_support_shepherd_drawColor,
-                getPosASLVisual _x,
-                24,
-                24,
-                getDirVisual _x,
-                name _x,
-                1, // shadow
-                [FONT_SIZE, 0] select (ctrlMapScale _ctrlMap > 0.01)
-            ];
-        } forEach units player;
-    }];
-};
+vgm_squad_ui_mapDrawEveryone = _known;

--- a/game/functions/systems/squad_ui/client/fn_squad_ui_postInit.sqf
+++ b/game/functions/systems/squad_ui/client/fn_squad_ui_postInit.sqf
@@ -9,76 +9,112 @@
         Squad UI component client post init.
  */
 
-#define ICON_WOUND_MINOR "\a3\ui_f\data\IGUI\Cfg\Revive\overlayIconsGroup\r50_ca.paa"
-#define ICON_WOUND_MAJOR "\a3\ui_f\data\IGUI\Cfg\Revive\overlayIconsGroup\r75_ca.paa"
-#define ICON_BLEEDING "\a3\ui_f\data\IGUI\Cfg\Revive\overlayIconsGroup\r100_ca.paa"
-#define ICON_INCAPACITATED "\a3\ui_f\data\IGUI\Cfg\Revive\overlayIconsGroup\u100_ca.paa"
-
 if (!hasInterface) exitWith {};
 
-vgm_squad_ui_defaultIcon = if (difficultyOption "groupIndicators" > 0) then {""} else {getMissionPath "assets\hex_ca.paa"};
+// 3d indicators
+call {
+    #define ICON_WOUND_MINOR "\a3\ui_f\data\IGUI\Cfg\Revive\overlayIconsGroup\r50_ca.paa"
+    #define ICON_WOUND_MAJOR "\a3\ui_f\data\IGUI\Cfg\Revive\overlayIconsGroup\r75_ca.paa"
+    #define ICON_BLEEDING "\a3\ui_f\data\IGUI\Cfg\Revive\overlayIconsGroup\r100_ca.paa"
+    #define ICON_INCAPACITATED "\a3\ui_f\data\IGUI\Cfg\Revive\overlayIconsGroup\u100_ca.paa"
 
-vgm_squad_ui_draw3dEH = addMissionEventHandler ["Draw3D", {
-    private _player = player;
-    {
-        private _icon = _x getVariable ["vgm_squad_ui_icon", vgm_squad_ui_defaultIcon];
-        if (_icon isNotEqualTo "") then {
-            private _fade = linearConversion [15, 100, _player distance _x, 0.8, 0, true];
+    vgm_squad_ui_defaultIcon = if (difficultyOption "groupIndicators" > 0) then {""} else {getMissionPath "assets\hex_ca.paa"};
 
-            drawIcon3D [
-                _icon,
-                [0.8,0.8,0.8,_fade],
-                unitAimPositionVisual _x,
-                1.5,
-                1.5,
-                0
-            ];
+    vgm_squad_ui_draw3dEH = addMissionEventHandler ["Draw3D", {
+        private _player = player;
+        {
+            private _icon = _x getVariable ["vgm_squad_ui_icon", vgm_squad_ui_defaultIcon];
+            if (_icon isNotEqualTo "") then {
+                private _fade = linearConversion [15, 100, _player distance _x, 0.8, 0, true];
+
+                drawIcon3D [
+                    _icon,
+                    [0.8,0.8,0.8,_fade],
+                    unitAimPositionVisual _x,
+                    1.5,
+                    1.5,
+                    0
+                ];
+            };
+        } forEach (units _player - [_player]);
+    }];
+
+    ["vgm_medical_unconscious", {
+        (_this#0) params ["_unit", "_state"];
+
+        if (_state) then {
+            _unit setVariable ["vgm_squad_ui_icon", ICON_INCAPACITATED, true];
+        } else {
+            _unit setVariable ["vgm_squad_ui_icon", nil, true];
         };
-    } forEach (units _player - [_player]);
-}];
+    }] call para_g_fnc_event_subscribeLocal;
 
-["vgm_medical_unconscious", {
-    (_this#0) params ["_unit", "_state"];
+    ["vgm_medical_woundAdded", {
+        (_this#0) params ["_unit"];
+        if (lifeState _unit == "INCAPACITATED") exitWith {};
 
-    if (_state) then {
-        _unit setVariable ["vgm_squad_ui_icon", ICON_INCAPACITATED, true];
-    } else {
+        if ([_unit, "bleeding"] call vgm_c_fnc_statusEffect_get) exitWith {
+            _unit setVariable ["vgm_squad_ui_icon", ICON_BLEEDING, true];
+        };
+
+        private _wounds = [_unit, "total"] call vgm_c_fnc_medical_getWound;
+        if (_wounds > 3) exitWith {
+            _unit setVariable ["vgm_squad_ui_icon", ICON_WOUND_MAJOR, true];
+        };
+        if (_wounds > 1) exitWith {
+            _unit setVariable ["vgm_squad_ui_icon", ICON_WOUND_MINOR, true];
+        };
+
+    }] call para_g_fnc_event_subscribeLocal;
+
+    ["vgm_medical_woundRemoved", {
+        (_this#0) params ["_unit"];
+        if (lifeState _unit == "INCAPACITATED") exitWith {};
+
+        if ([_unit, "bleeding"] call vgm_c_fnc_statusEffect_get) exitWith {};
+
+        private _wounds = [_unit, "total"] call vgm_c_fnc_medical_getWound;
+        if (_wounds > 3) exitWith {
+            _unit setVariable ["vgm_squad_ui_icon", ICON_WOUND_MAJOR, true];
+        };
+        if (_wounds > 1) exitWith {
+            _unit setVariable ["vgm_squad_ui_icon", ICON_WOUND_MINOR, true];
+        };
+
         _unit setVariable ["vgm_squad_ui_icon", nil, true];
+
+    }] call para_g_fnc_event_subscribeLocal;
+};
+
+// map indicators
+call {
+    #define FONT_SIZE 0.042
+    #define CTRL_MAP (findDisplay 12 displayCtrl 51)
+
+    vgm_squad_ui_playerColor = playerSide call BIS_fnc_sideColor;
+
+    [] spawn {
+        waitUntil {!isNull CTRL_MAP};
+
+        vgm_squad_ui_drawMapEH = CTRL_MAP ctrlAddEventHandler ["Draw", {
+            params ["_ctrlMap"];
+
+            private _leader = leader player;
+            private _units = if (vgm_squad_ui_mapDrawEveryone) then {units player} else {[_leader]};
+
+            {
+                _ctrlMap drawIcon [
+                    ["iconMan", "iconManLeader"] select (_x isEqualTo _leader),
+                    vgm_squad_ui_playerColor,
+                    getPosASLVisual _x,
+                    24,
+                    24,
+                    getDirVisual _x,
+                    name _x,
+                    1, // shadow
+                    [FONT_SIZE, 0] select (ctrlMapScale _ctrlMap > 0.01)
+                ];
+            } forEach _units;
+        }];
     };
-}] call para_g_fnc_event_subscribeLocal;
-
-["vgm_medical_woundAdded", {
-    (_this#0) params ["_unit"];
-    if (lifeState _unit == "INCAPACITATED") exitWith {};
-
-    if ([_unit, "bleeding"] call vgm_c_fnc_statusEffect_get) exitWith {
-        _unit setVariable ["vgm_squad_ui_icon", ICON_BLEEDING, true];
-    };
-
-    private _wounds = [_unit, "total"] call vgm_c_fnc_medical_getWound;
-    if (_wounds > 3) exitWith {
-        _unit setVariable ["vgm_squad_ui_icon", ICON_WOUND_MAJOR, true];
-    };
-    if (_wounds > 1) exitWith {
-        _unit setVariable ["vgm_squad_ui_icon", ICON_WOUND_MINOR, true];
-    };
-
-}] call para_g_fnc_event_subscribeLocal;
-
-["vgm_medical_woundRemoved", {
-    (_this#0) params ["_unit"];
-    if (lifeState _unit == "INCAPACITATED") exitWith {};
-
-    if ([_unit, "bleeding"] call vgm_c_fnc_statusEffect_get) exitWith {};
-
-    private _wounds = [_unit, "total"] call vgm_c_fnc_medical_getWound;
-    if (_wounds > 3) exitWith {
-        _unit setVariable ["vgm_squad_ui_icon", ICON_WOUND_MAJOR, true];
-    };
-    if (_wounds > 1) exitWith {
-        _unit setVariable ["vgm_squad_ui_icon", ICON_WOUND_MINOR, true];
-    };
-
-    _unit setVariable ["vgm_squad_ui_icon", nil, true];
-
-}] call para_g_fnc_event_subscribeLocal;
+};

--- a/game/functions/systems/squad_ui/client/fn_squad_ui_preInit.sqf
+++ b/game/functions/systems/squad_ui/client/fn_squad_ui_preInit.sqf
@@ -1,0 +1,14 @@
+/*
+    File: fn_squad_ui_preInit.sqf
+    Author: Savage Game Design
+    Date: 2024-07-04
+    Last Update: 2024-07-04
+    Public: No
+
+    Description:
+        Squad UI component client pre init.
+ */
+
+if (!hasInterface) exitWith {};
+
+vgm_squad_ui_mapDrawEveryone = false;


### PR DESCRIPTION
- Move the map icon draw handler to Squad UI
- Draw only leader unless "Shepherd" skill is known