### PR TITLE
Adds object grabber/mapper

### DIFF
--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -247,6 +247,14 @@ class vgm_g
         };
     };
 
+    class object_grabber
+    {
+        VGM_GLOBAL_PATH(\systems\object_grabber\global);
+
+        class objGrabber_eden_grab {};
+        class objGrabber_map {};
+    };
+
     class skills
     {
         VGM_GLOBAL_PATH(\systems\skills\global);

--- a/game/functions/systems/object_grabber/global/fn_objGrabber_eden_grab.sqf
+++ b/game/functions/systems/object_grabber/global/fn_objGrabber_eden_grab.sqf
@@ -1,0 +1,81 @@
+/*
+    File: fn_objGrabber_eden_grab.sqf
+    Author: Joris-Jan van 't Land and Savage Game Design
+    Date: 2024-08-02
+    Last Update: 2024-08-10
+    Public: Yes
+
+    Description:
+        Converts a set of placed objects to an object array for the VGM version of the DynO mapper.
+
+    Parameter(s):
+        _grabOrientation - Whether to grab pitch/bank of the object [BOOLEAN]
+        _alignToSurfaceNormal - Whether objects should be aligned to the surface normal when placed [BOOLEAN]
+        _useTerrainHeight - Whether objects should spawn using their current height above their terrain, instead of absolute offset from other objects [BOOLEAN]
+
+    Returns:
+        Composition details [HashMap]
+
+    Example(s):
+        [true, true, false] call vgm_g_fnc_sites_objectGrabber
+ */
+
+
+params [["_ASL", true], ["_grabOrientation", true], ["_alignToSurfaceNormal", false], ["_useTerrainHeight", false]];
+
+private _fnc_getObjectsCenter = {
+	params ["_objs"];
+	private _center = [0, 0, 0];
+
+	{
+		_center = _center vectorAdd getPosWorld _x;
+	} forEach _objs;
+
+	private _averageMultiplier = 1 / (count _objs);
+	_center = _center vectorMultiply [_averageMultiplier, _averageMultiplier, _averageMultiplier];
+
+	ATLtoASL [_center # 0, _center # 1, 0]
+};
+
+private _objs = get3DENSelected "object" select {!(_x isKindOf "Man")};
+private _centerASL = [_objs] call _fnc_getObjectsCenter;
+private _objectDetails = [];
+
+private _objectDetails = _objs apply {
+	private _type = typeOf _x;
+    private _posWorld = getPosWorld _x;
+    private _posATL = ASLtoATL _posWorld;
+	private _vectorDiff = _posWorld vectorDiff _centerASL;
+	private _dX = _vectorDiff # 0;
+	private _dY = _vectorDiff # 1;
+    // Z relative to the composition center point.
+	private _relativeZ = _vectorDiff # 2;
+    // Z of this object relative to the terrain at its position (i.e - height above terrain)
+    private _terrainZ = _posATL # 2;
+	private _vectorDir = vectorDir _x;
+	private _vectorUp = vectorUp _x;
+	private _fuel = fuel _x;
+	private _damage = damage _x;
+	private _init = _x get3DENAttribute "Init" select 0;
+	private _simulation = _x get3DENAttribute "enableSimulation" select 0;
+	private _allowDamage = _x get3DENAttribute "allowDamage" select 0;
+    // Mapper will set this so it persists across placed objects if manually edited later.
+    private _useObjectTerrainHeight = _x getVariable ["useTerrainHeight", _useTerrainHeight];
+
+	[_type, [_dX, _dY], _relativeZ, _terrainZ, _vectorDir, _vectorUp, _fuel, _damage, _init, _simulation, _allowDamage, _useObjectTerrainHeight];
+};
+
+// Sort objects by disabled simulation, then by height, so any objects resting on other objects don't fall through when spawning.
+private _sortedByHeight = [];
+{
+    _sortedByHeight pushBack [!(_x # 9), _x # 2, _forEachIndex];
+} forEach _objectDetails;
+_sortedByHeight sort true;
+
+private _objectDetails = _sortedByHeight apply {_objectDetails # (_x # 2)};
+
+private _output = _objectDetails;
+
+copyToClipboard str _output;
+
+_output

--- a/game/functions/systems/object_grabber/global/fn_objGrabber_eden_grab.sqf
+++ b/game/functions/systems/object_grabber/global/fn_objGrabber_eden_grab.sqf
@@ -21,7 +21,11 @@
  */
 
 
-params [["_ASL", true], ["_grabOrientation", true], ["_alignToSurfaceNormal", false], ["_useTerrainHeight", false]];
+params [
+    ["_grabOrientation", true],
+    ["_alignToSurfaceNormal", false],
+    ["_useTerrainHeight", false]
+];
 
 private _fnc_getObjectsCenter = {
 	params ["_objs"];
@@ -32,7 +36,7 @@ private _fnc_getObjectsCenter = {
 	} forEach _objs;
 
 	private _averageMultiplier = 1 / (count _objs);
-	_center = _center vectorMultiply [_averageMultiplier, _averageMultiplier, _averageMultiplier];
+	_center = _center vectorMultiply _averageMultiplier;
 
 	ATLtoASL [_center # 0, _center # 1, 0]
 };

--- a/game/functions/systems/object_grabber/global/fn_objGrabber_map.sqf
+++ b/game/functions/systems/object_grabber/global/fn_objGrabber_map.sqf
@@ -1,0 +1,86 @@
+/*
+	File: fn_objGrabber_map.sqf
+	Author: Joris-Jan van't Land and Savage Game Design
+	Date: 2024-08-10
+	Last Update: 2024-08-10
+	Public: Yes
+
+	Description:
+		Takes an array of data about a dynamic object template and creates the objects.
+
+	Parameter(s):
+		_pos - Position of the template in AGL/ATL [ARRAY]
+		_azi - Rotation to apply to the template in degrees (clockwise) [NUMBER]
+		_objs - Array of objects produced by vgm_g_fnc_objGrabber_eden_grab [ARRAY]
+
+	Returns:
+		Spawned objects [ARRAY]
+
+	Example(s):
+		[[0, 0, 0], 0, []] call vgm_g_fnc_sites_objectsMapper;
+ */
+
+params ["_pos", ["_azi", 0], ["_objs", []]];
+
+_pos params ["_posX", "_posY"];
+private _posASL = AGLtoASL _pos;
+private _newObjs = [];
+
+{
+	_x params [
+		"_type",
+		"_pos2D",
+		"_relativeZ",
+		"_terrainZ",
+		"_vectorDir",
+		"_vectorUp",
+		"_fuel",
+		"_damage",
+		"_initCode",
+		"_simulation",
+        "_allowDamage",
+		"_useObjectTerrainHeight"
+	];
+
+
+	//Rotate the relative position using a rotation matrix
+	private _rotMatrix =
+	[
+		[cos -_azi, sin -_azi],
+		[-(sin -_azi), cos -_azi]
+	];
+	private _newRelPos = ([_pos2D] matrixMultiply _rotMatrix) # 0;
+	private _newPos = [];
+	private _newPosASL = [];
+
+	if (_useObjectTerrainHeight) then {
+		_newPos = _newRelPos vectorAdd _pos vectorAdd [0, 0, _terrainZ];
+		_newPosASL = AGLtoASL _newPos;
+	} else {
+		_newPosASL = _newRelPos vectorAdd _posASL vectorAdd [0, 0, _relativeZ];
+		_newPos = ASLtoAGL _newPosASL;
+	};
+
+	private _newVectorDir = [_vectorDir, _azi, 2] call BIS_fnc_rotateVector3D;
+	private _newVectorUp = [_vectorUp, _azi, 2] call BIS_fnc_rotateVector3D;
+
+	//Create the object and make sure it's in the correct location
+	private _newObj = createVehicle [_type, _newPos, [], 0, "CAN_COLLIDE"];
+	_newObj setVectorDirAndUp [_newVectorDir, _newVectorUp];
+	_newObj setPosWorld _newPosASL;
+
+
+    // Set this so that if it gets re-grabbed, the setting persists. Useful if a particular object was manually altered.
+	_newObj setVariable ["useTerrainHeight", _useObjectTerrainHeight];
+
+	//If fuel and damage were grabbed, map them
+	if (!isNil "_fuel") then {_newObj setFuel _fuel};
+	if (!isNil "_damage") then {_newObj setDamage _damage;};
+	if (!isNil "_init") then {_newObj call (compile ("this = _this; " + _initCode));};
+	if (!isNil "_simulation") then {_newObj enableSimulationGlobal _simulation};
+	if (!isNil "_allowDamage") then {_newObj allowDamage _allowDamage};
+
+	_newObjs pushBack _newObj;
+} forEach _objs;
+
+_newObjs


### PR DESCRIPTION
Adds a custom object grabber / spawner based on BI's code.

Main differences:
- All objects are created relative to the center point by default, including height.
- Orientations are all persisted and rotated correctly by default.
- Option to make certain objects use their position above terrain when they were grabbed. (e.g - always spawn this at height 0 ATL).

