### PR TITLE
Indexes LZ locations

### DIFF
--- a/game/functions/functions_server.hpp
+++ b/game/functions/functions_server.hpp
@@ -212,14 +212,15 @@ class vgm_s
     {
         VGM_SERVER_PATH(\systems\locations\server);
 
-        class loc_areSiteRequirementsMet {};
+        class loc_areRequirementsMet {};
         class loc_eden_createLocationIndexAllTargetBoxes {};
         class loc_eden_getLocationsByTargetBox {};
-        class loc_eden_getSiteLocationsByTargetBox {};
+        class loc_eden_indexAllTargetBoxLocations {};
         class loc_eden_getTargetBoxLayers {};
         class loc_eden_getTargetBoxMarkers {};
-        class loc_eden_showSiteOverlay {};
-        class loc_eden_showSitesReport {};
+        class loc_eden_showOverlay {};
+        class loc_eden_showReport {};
+        class loc_getLocationTypes {};
         class loc_getTargetBoxLocations {};
         class loc_preInit {
             preInit = 1;
@@ -254,6 +255,7 @@ class vgm_s
         class sites_delete {};
         class sites_getAllSiteTypes {};
         class sites_getSiteType {};
+        class sites_getSiteTypeRequirements {};
         class sites_getTemplate {};
         class sites_loadSiteTypesFromConfig {};
         class sites_spawn {};

--- a/game/functions/systems/locations/server/fn_loc_areRequirementsMet.sqf
+++ b/game/functions/systems/locations/server/fn_loc_areRequirementsMet.sqf
@@ -1,27 +1,28 @@
 /*
-    File: fn_sites_areSiteRequirementsMet.sqf
+    File: fn_sites_areRequirementsMet.sqf
     Author: Savage Game Design
     Date: 2024-07-04
-    Last Update: 2024-07-04
+    Last Update: 2024-08-21
     Public: Yes
 
     Description:
-        Given a site and a list of tags, determines if the tags meet the site's requirements to be spawned.
+        Given a list of site requirements, and a list of location tags, determines if the tags meet the site's requirements to be spawned.
 
     Parameter(s):
-        _site - Site to check [HashMap]
+        _requirements - List of tags to check [ARRAY]
         _locTags - Tags to check against. Must be all lower case. [ARRAY]
 
     Returns:
         True if the tags meet the site's requirements, false otherwise [Boolean]
 
     Example(s):
-        [_mySite, ["small", "jungle"]] call vgm_s_fnc_sites_locRequirementsMet;
+        [
+            [_mySite] call vgm_s_fnc_sites_getSiteTypeRequirements,
+            ["small", "jungle"]
+        ] call vgm_s_fnc_sites_locRequirementsMet;
  */
 
-params ["_site", "_locTags"];
-
-private _requirements = (_site get "locRequirements") + [_site get "size"];
+params ["_requirements", "_locTags"];
 
 // If no requirements are lost after array intersection, then all requirements are satisfied.
 count (_locTags arrayIntersect _requirements) isEqualTo count (_requirements)

--- a/game/functions/systems/locations/server/fn_loc_eden_createLocationIndexAllTargetBoxes.sqf
+++ b/game/functions/systems/locations/server/fn_loc_eden_createLocationIndexAllTargetBoxes.sqf
@@ -2,13 +2,13 @@
     File: fn_loc_eden_createLocationIndexAllTargetBoxes.sqf
     Author: Savage Game Design
     Date: 2024-05-25
-    Last Update: 2024-07-27
+    Last Update: 2024-08-21
     Public: Yes
 
     Description:
         Creates an index of all marked locations in 3DEN, and writes it to the mission.sqm as Logic entities.
 
-        See vgm_s_fnc_loc_eden_getSiteLocationsByTargetBox for more information on the indexing process.
+        See vgm_s_fnc_loc_eden_indexAllTargetBoxLocations for more information on the indexing process.
 
     Parameter(s):
         None
@@ -20,7 +20,7 @@
         [] call vgm_s_fnc_loc_eden_createLocationIndexAllTargetBoxes;
  */
 
-private _siteLocationsByTargetBox = [] call vgm_s_fnc_loc_eden_getSiteLocationsByTargetBox;
+private _siteLocationsByTargetBox = [] call vgm_s_fnc_loc_eden_indexAllTargetBoxLocations;
 private _targetBoxLayers = [] call vgm_s_fnc_loc_eden_getTargetBoxLayers;
 
 {

--- a/game/functions/systems/locations/server/fn_loc_eden_indexAllTargetBoxLocations.sqf
+++ b/game/functions/systems/locations/server/fn_loc_eden_indexAllTargetBoxLocations.sqf
@@ -1,8 +1,8 @@
 /*
-    File: fn_loc_eden_getSiteLocationsByTargetBox.sqf
+    File: fn_loc_eden_indexAllTargetBoxLocations.sqf
     Author: Savage Game Design
     Date: 2024-05-25
-    Last Update: 2024-07-22
+    Last Update: 2024-08-21
     Public: Yes
 
     Description:
@@ -22,12 +22,12 @@
         [] call vgm_s_fnc_loc_eden_getSiteLocationsByTargetBox;
  */
 
-[] call vgm_s_fnc_sites_loadSiteTypesFromConfig;
 
 private _locationsByTargetBox = [] call vgm_s_fnc_loc_eden_getLocationsByTargetBox;
 
 private _locationIndex = createHashMap;
-private _siteTypes = values ([] call vgm_s_fnc_sites_getAllSiteTypes);
+
+private _locationTypesWithRequirements = [] call vgm_s_fnc_loc_getLocationTypes;
 
 {
     private _zoneId = _x;
@@ -36,18 +36,18 @@ private _siteTypes = values ([] call vgm_s_fnc_sites_getAllSiteTypes);
     _locationIndex set [_zoneId, _currentZoneIndex];
 
     {
-        private _currentSiteTypeLocationsInZone = [];
-        private _siteType = _x;
-        _currentZoneIndex set [_siteType get "id", _currentSiteTypeLocationsInZone];
+        private _currentLocationTypesInZone = [];
+        private _locationType = _x;
+        _currentZoneIndex set [_locationType get "id", _currentLocationTypesInZone];
 
         {
             private _locData = _x;
 
-            if ([_siteType, _locData get "tags"] call vgm_s_fnc_loc_areSiteRequirementsMet) then {
-                _currentSiteTypeLocationsInZone pushBack _locData;
+            if ([_locationType get "requirements", _locData get "tags"] call vgm_s_fnc_loc_areRequirementsMet) then {
+                _currentLocationTypesInZone pushBack _locData;
             };
         } forEach _locations;
-    } forEach _siteTypes;
+    } forEach values _locationTypesWithRequirements;
 } forEach _locationsByTargetBox;
 
 _locationIndex

--- a/game/functions/systems/locations/server/fn_loc_eden_showOverlay.sqf
+++ b/game/functions/systems/locations/server/fn_loc_eden_showOverlay.sqf
@@ -1,12 +1,12 @@
 /*
-    File: fn_loc_eden_showSiteOverlay.sqf
+    File: fn_loc_eden_showOverlay.sqf
     Author: Savage Game Design
     Date: 2024-07-04
-    Last Update: 2024-08-01
+    Last Update: 2024-08-21
     Public: Yes
 
     Description:
-        Shows an overlay over site locations in 3DEN, with valid sites for that loc.
+        Shows an overlay of locations in 3DEN, with valid location types for that loc.
 
     Parameter(s):
         N/A
@@ -15,27 +15,24 @@
         Nothing
 
     Example(s):
-        [] call vgm_s_fnc_loc_eden_showSiteOverlay
+        [] call vgm_s_fnc_loc_eden_showOverlay
  */
 
-if (!isNil "vgm_s_loc_eden_siteOverlayDrawHandler") exitWith {};
+if (!isNil "vgm_s_loc_eden_overlayDrawHandler") exitWith {};
 
-[] call vgm_s_fnc_sites_loadSiteTypesFromConfig;
-
-vgm_s_loc_eden_siteOverlay = createHashMap;
-vgm_s_loc_eden_siteOverlayTargetBoxes = [];
+vgm_s_loc_eden_overlay = createHashMap;
+vgm_s_loc_eden_overlayTargetBoxes = [];
 // This can be refactored to be run once then be event driven, after 2.18 releases with "OnEntityAttributeChanged".
-vgm_s_loc_eden_siteOverlayUpdater = [] spawn {
-    // Get a list of sites sorted by name.
-    private _allSiteTypes = [] call vgm_s_fnc_sites_getAllSiteTypes;
-    private _siteTypeIds = values (_allSiteTypes);
-    private _sortedSites = _siteTypeIds apply {[(_x get "name") call para_c_fnc_localize, _x get "id"]};
-    _sortedSites sort false;
-    private _siteTypes = _sortedSites apply {_allSiteTypes get (_x # 1)};
-    private _siteNamesById = (_sortedSites apply {_x # 1}) createHashMapFromArray (_sortedSites apply {_x # 0});
+vgm_s_loc_eden_overlayUpdater = [] spawn {
+    // Get a list of location types sorted by name.
+    private _locationTypesById = [] call vgm_s_fnc_loc_getLocationTypes;
+    private _locationTypes = values _locationTypesById;
+    private _sortedLocationTypeIds = _locationTypes apply {[_x get "name", _x get "id"]};
+    _sortedLocationTypeIds sort false;
+    private _sortedLocationTypes = _sortedLocationTypeIds apply {_locationTypesById get (_x # 1)};
 
 
-    while {!isNil "vgm_s_loc_eden_siteOverlay"} do {
+    while {!isNil "vgm_s_loc_eden_overlay"} do {
         private _targetBoxLocs = [] call vgm_s_fnc_loc_eden_getLocationsByTargetBox;
 
         {
@@ -43,22 +40,22 @@ vgm_s_loc_eden_siteOverlayUpdater = [] spawn {
             private _locs = _y;
             {
                 private _tags = _x get "tags";
-                private _validSites = _siteTypes select {[_x, _tags] call vgm_s_fnc_loc_areSiteRequirementsMet} apply {_siteNamesById get (_x get "id")};
-                vgm_s_loc_eden_siteOverlay set [_x get "edenId", _validSites];
+                private _validLocationTypes = _sortedLocationTypes select {[_x get "requirements", _tags] call vgm_s_fnc_loc_areRequirementsMet} apply {_x get "name"};
+                vgm_s_loc_eden_overlay set [_x get "edenId", _validLocationTypes];
             } forEach _locs;
         } forEach _targetBoxLocs;
 
-        vgm_s_loc_eden_siteOverlayTargetBoxMarkers = [] call vgm_s_fnc_loc_eden_getTargetBoxMarkers;
+        vgm_s_loc_eden_overlayTargetBoxMarkers = [] call vgm_s_fnc_loc_eden_getTargetBoxMarkers;
 
         uiSleep 5;
     };
 };
 
-vgm_s_loc_eden_siteOverlayDrawHandler = addMissionEventHandler ["Draw3D", {
+vgm_s_loc_eden_overlayDrawHandler = addMissionEventHandler ["Draw3D", {
 	private _maxDistance = 3500;
 	{
 		private _id = _x;
-		private _siteNames = _y;
+		private _locationNames = _y;
 
 		private _pos = ASLToATL (_id get3DENAttribute "Position" select 0);
 		private _textPos = _pos vectorAdd [0, 0, 100];
@@ -67,15 +64,15 @@ vgm_s_loc_eden_siteOverlayDrawHandler = addMissionEventHandler ["Draw3D", {
 
 		{
 			drawIcon3D ["", [1,1,1,_opacity], _textPos, 1, 1, 45, _x, 1, 0.03, "TahomaB", "center", false, 0, -0.03 + -0.015 * _forEachIndex];
-		} forEach _siteNames;
+		} forEach _locationNames;
 
-		if (_siteNames isEqualTo []) then {
+		if (_locationNames isEqualTo []) then {
 			drawIcon3D ["", [1,1,0.3,_opacity], _textPos, 0, 0, 45, "None", 2, 0.05, "TahomaB", "center", false, 0, -0.03];
 		};
 
         drawLine3D [_textPos, _pos, [1,1,1,_opacity]];
 
-	} forEach vgm_s_loc_eden_siteOverlay;
+	} forEach vgm_s_loc_eden_overlay;
 
     {
         private _pos = _x get3DENAttribute "Position" select 0;
@@ -98,5 +95,5 @@ vgm_s_loc_eden_siteOverlayDrawHandler = addMissionEventHandler ["Draw3D", {
         {
             drawLine3D [_x # 0, _x # 1, [1, 1, 1, _opacity]];
         } forEach _lines;
-    } forEach vgm_s_loc_eden_siteOverlayTargetBoxMarkers;
+    } forEach vgm_s_loc_eden_overlayTargetBoxMarkers;
 }];

--- a/game/functions/systems/locations/server/fn_loc_eden_showReport.sqf
+++ b/game/functions/systems/locations/server/fn_loc_eden_showReport.sqf
@@ -1,8 +1,8 @@
 /*
-    File: fn_loc_eden_showSitesReport.sqf
+    File: fn_loc_eden_showReport.sqf
     Author: Savage Game Design
     Date: 2024-07-27
-    Last Update: 2024-07-27
+    Last Update: 2024-08-21
     Public: No
 
     Description:
@@ -15,23 +15,23 @@
         N/A
 
     Example(s):
-        [] call vgm_s_fnc_loc_eden_showSitesReport;
+        [] call vgm_s_fnc_loc_eden_showReport;
  */
 
-private _targetBoxIndexes = [] call vgm_s_fnc_loc_eden_getSiteLocationsByTargetBox;
-private _siteTypes = values ([] call vgm_s_fnc_sites_getAllSiteTypes);
+private _targetBoxIndexes = [] call vgm_s_fnc_loc_eden_indexAllTargetBoxLocations;
+private _locationTypes = values ([] call vgm_s_fnc_loc_getLocationTypes);
 
 private _perTargetBoxReports = [];
 
 {
 	private _targetBoxName = _x;
 	private _siteLocations = _y;
-	private _siteReports = createHashMap;
+	private _reports = createHashMap;
 
 	{
-		private _siteTemplate = _x;
-		private _positions = _siteLocations getOrDefault [_siteTemplate get "id", []];
-		private _siteName = (_siteTemplate get "name") call para_c_fnc_localize;
+		private _locationType = _x;
+		private _positions = _siteLocations getOrDefault [_locationType get "id", []];
+		private _locTypeName = _locationType get "name";
 
         // Get total number of positions and color-code accordingly.
 		private _totalPositions = count _positions;
@@ -39,33 +39,33 @@ private _perTargetBoxReports = [];
 		private _colorConditions = [_totalPositions <= 0, _totalPositions <= 2, true];
 		private _positionCountColor = _colors select (_colorConditions find true);
 
-		private _siteRequirements = str (([_siteTemplate get "size"]) + (_siteTemplate get "locRequirements"));
+		private _siteRequirements = str (_locationType get "requirements");
 
         // Prepare individual report lines for formatting.
         // Splitting it into lines makes it easier to change later, as the format numbers stay low.
-		private _siteReportLines = [
+		private _reportLines = [
 			["<t size='1.3'>%1 - <t color='%3'>%2</t></t>",
-				[_siteName, _totalPositions, _positionCountColor]],
+				[_locTypeName, _totalPositions, _positionCountColor]],
 			["Required tags: %1",
 				[_siteRequirements]]
 		];
 
-		_siteReportLines = _siteReportLines apply { _x params ["_template", "_args"]; format ([_template] + _args) };
+		_reportLines = _reportLines apply { _x params ["_template", "_args"]; format ([_template] + _args) };
 
-		private _siteReport = _siteReportLines joinString "<br/>";
+		private _report = _reportLines joinString "<br/>";
 
-		_siteReports set [_siteName, _siteReport];
-	} forEach _siteTypes;
+		_reports set [_locTypeName, _report];
+	} forEach _locationTypes;
 
     // Sort reports by site name, ensuring consistency across different reports.
-	private _siteNames = keys _siteReports;
-	_siteNames sort true;
+	private _locTypeNames = keys _reports;
+	_locTypeNames sort true;
 	private _targetBoxReportLines = [];
 
     // Join all the individual site reports into one big eport.
 	{
-		_targetBoxReportLines pushBack (_siteReports get _x);
-	} forEach _siteNames;
+		_targetBoxReportLines pushBack (_reports get _x);
+	} forEach _locTypeNames;
 
 	private _targetBoxReport = parseText (_targetBoxReportLines joinString "<br/>");
 

--- a/game/functions/systems/locations/server/fn_loc_getLocationTypes.sqf
+++ b/game/functions/systems/locations/server/fn_loc_getLocationTypes.sqf
@@ -1,0 +1,41 @@
+/*
+    File: fn_loc_getLocationTypes.sqf
+    Author: Savage Game Design
+    Date: 2024-08-21
+    Last Update: 2024-08-21
+    Public: Yes
+
+    Description:
+        Retrieves all location types, and their required tags
+
+    Parameter(s):
+        None
+
+    Returns:
+        Map from a location ID to a location type [HASHMAP]
+
+    Example(s):
+        [] call vgm_s_fnc_loc_getLocationTypes;
+ */
+
+[] call vgm_s_fnc_sites_loadSiteTypesFromConfig;
+
+private _siteTypes = values ([] call vgm_s_fnc_sites_getAllSiteTypes);
+private _locationTypes = createHashMapFromArray (
+    _siteTypes apply {
+        [_x get "id", createHashMapFromArray [
+            ["id", _x get "id"],
+            ["name", (_x get "name") call para_c_fnc_localize],
+            ["requirements", [_x] call vgm_s_fnc_sites_getSiteTypeRequirements]
+        ]]
+    }
+);
+
+// Custom location types. Ideally move this to config, but this works for the moment with only a tiny number of edge cases.
+_locationTypes set ["lz", createHashMapFromArray [
+    ["id", "lz"],
+    ["name", "STR_VGM_LOCATIONS_LZ" call para_c_fnc_localize],
+    ["requirements", ["lz"]]
+]];
+
+_locationTypes

--- a/game/functions/systems/sites/server/fn_sites_getSiteTypeRequirements.sqf
+++ b/game/functions/systems/sites/server/fn_sites_getSiteTypeRequirements.sqf
@@ -1,0 +1,30 @@
+/*
+    File: fn_sites_getSiteTypeRequirements.sqf
+    Author: Savage Game Design
+    Date: 2024-08-21
+    Last Update: 2024-08-21
+    Public: No
+
+    Description:
+        Returns a list of the required tags for the given site type.
+
+    Parameter(s):
+        _siteType - The site type to analyse [HASHMAP]
+
+    Returns:
+        List of required tags [ARRAY]
+
+    Example(s):
+        private _mySiteType = ["vgm_something"] call vgm_s_fnc_sites_getSiteType;
+        private _requirements = [_mySiteType] call vgm_s_fnc_sites_getSiteTypeRequirements;
+ */
+
+params ["_siteType"];
+
+private _requirements = _siteType getOrDefault ["locRequirements", []];
+
+if ("size" in _siteType) then {
+    _requirements pushBack (_siteType get "size");
+};
+
+_requirements

--- a/game/mission/init3DEN.sqf
+++ b/game/mission/init3DEN.sqf
@@ -1,1 +1,1 @@
-[] call vgm_s_fnc_loc_eden_showSiteOverlay;
+[] call vgm_s_fnc_loc_eden_showOverlay;

--- a/game/mission/stringtable.xml
+++ b/game/mission/stringtable.xml
@@ -415,6 +415,11 @@
             <Original>Settings</Original>
         </Key>
     </Package>
+    <Package name="Locations">
+        <Key ID="STR_VGM_LOCATIONS_LZ">
+            <Original>LZ</Original>
+        </Key>
+    </Package>
     <Package name="Sites">
         <Key ID="STR_VGM_SITES_AA">
             <Original>Anti-aircraft gun</Original>


### PR DESCRIPTION
Adds LZ locations to the terrain indexes.

Decouples the location system from the site system, to allow us to inject custom location types without needing new sites.

(Using sites would complicate all future spawning)