### PR TITLE
Missions - Spawn random sites on mission start

### DIFF
--- a/game/configs/mission/cfg_site_types.hpp
+++ b/game/configs/mission/cfg_site_types.hpp
@@ -21,6 +21,8 @@ class vgm_site_types {
     };
 
     class vgm_campfire {
+        /* Intended for debug only */
+        disabled = 1;
         generatorFunction = "vgm_s_fnc_sites_type_campfire";
     };
 
@@ -29,6 +31,8 @@ class vgm_site_types {
     };
 
     class vgm_shelter {
+        /* Intended for debug only */
+        disabled = 1;
         generatorFunction = "vgm_s_fnc_sites_type_shelter";
     };
 

--- a/game/functions/functions_server.hpp
+++ b/game/functions/functions_server.hpp
@@ -163,6 +163,7 @@ class vgm_s
 
         class missions_zones_clearSites {};
         class missions_zones_freeZone {};
+        class missions_zones_getSites {};
         class missions_zones_getStartPos {};
         class missions_zones_preInit
         {

--- a/game/functions/functions_server.hpp
+++ b/game/functions/functions_server.hpp
@@ -161,6 +161,7 @@ class vgm_s
     {
         VGM_SERVER_PATH(\systems\missions_zones\server);
 
+        class missions_zones_clearSites {};
         class missions_zones_freeZone {};
         class missions_zones_getStartPos {};
         class missions_zones_preInit
@@ -168,6 +169,7 @@ class vgm_s
             preInit = 1;
         };
         class missions_zones_reserveZone {};
+        class missions_zones_spawnRandomSites {};
     };
     class missions_zones_remoteExec
     {

--- a/game/functions/systems/mission_director/server/fn_director_spawnInitialPatrols.sqf
+++ b/game/functions/systems/mission_director/server/fn_director_spawnInitialPatrols.sqf
@@ -2,7 +2,7 @@
     File: fn_director_spawnInitialPatrols.sqf
     Author:
     Date: 2023-09-29
-    Last Update: 2024-03-09
+    Last Update: 2024-08-24
     Public: No
 
     Description:
@@ -20,25 +20,19 @@
 
 params ["_mission"];
 
-private _insertionLocation = _mission get "public" get "startPosASL";
-private _objective = markerPos "marker_47";
-
-private _desiredSquads = vgm_s_director_patrol_max_groups;
-
-private _angleToObjective = _insertionLocation getDir _objective;
-private _spawnAngles = [_angleToObjective + 90, _angleToObjective - 90];
-private _spawnIntervalDistance = (_insertionLocation distance2D _objective) /_desiredSquads;
+private _missionPublic = _mission get "public";
+private _targetZone = _missionPublic get "targetZone";
+private _sites = [_targetZone] call vgm_s_fnc_missions_zones_getSites;
 
 private _squads = [];
 
-for "_i" from 1 to _desiredSquads do {
-    private _spawnCenterlinePos = _insertionLocation getPos [_spawnIntervalDistance * _i, _angleToObjective];
-    private _spawnPos = _spawnCenterlinePos getPos [100 + random 100, selectRandom _spawnAngles];
-
-    private _group = [vgm_s_director_patrol_classes, east, _spawnPos, _mission get "public" get "id"] call vgm_s_fnc_ai_createEnemySquad;
+{
+    private _spawnPos = _x get "pos" getPos [10 + random 100, random 360];
+    private _group = [vgm_s_director_patrol_classes, east, _spawnPos, _missionPublic get "id"] call vgm_s_fnc_ai_createEnemySquad;
     _group setVariable ["vgm_s_director_command", "patrol"];
     _squads pushBack _group;
-};
+} forEach _sites;
 
 [_mission, _squads] call vgm_s_fnc_director_registerGroups;
 _mission get "director" set ["initialAiGroups", _squads];
+

--- a/game/functions/systems/missions/server/fn_missions_endMission.sqf
+++ b/game/functions/systems/missions/server/fn_missions_endMission.sqf
@@ -2,7 +2,7 @@
     File: fn_missions_endMission.sqf
     Author:
     Date: 2023-02-26
-    Last Update: 2024-04-24
+    Last Update: 2024-08-24
     Public: No
 
     Description:
@@ -51,6 +51,7 @@ private _missionMemberMachineIds = values (_mission get "machineIds");
     [_missionPublic get "id", _endType]
 ] call para_g_fnc_event_triggerGlobal;
 
+[_missionPublic get "targetZone"] call vgm_s_fnc_missions_zones_clearSites;
 [_missionPublic get "targetZone"] call vgm_s_fnc_missions_zones_freeZone;
 [_mission] call vgm_s_fnc_director_stopMission;
 

--- a/game/functions/systems/missions/server/fn_missions_startMission.sqf
+++ b/game/functions/systems/missions/server/fn_missions_startMission.sqf
@@ -2,7 +2,7 @@
     File: fn_missions_startMission.sqf
     Author:
     Date: 2023-02-26
-    Last Update: 2023-12-20
+    Last Update: 2024-08-24
     Public: Yes
 
     Description:
@@ -36,6 +36,8 @@ if (_missionPublic get "status" isNotEqualTo "CREATED") exitWith {
 [_mission, "mission started", true] call vgm_s_fnc_missions_preventJoining;
 
 [] remoteExecCall ["vgm_c_fnc_missions_startDeploy", values (_mission get "machineIds")];
+
+[_missionPublic get "targetZone", 25] call vgm_s_fnc_missions_zones_spawnRandomSites;
 
 [_mission] call vgm_s_fnc_director_startMission;
 [_missionPublic get "startPosASL"] call vgm_s_fnc_missions_gameplay_ambient_departHelicopter; // TODO by what and where should this be fired?

--- a/game/functions/systems/missions_zones/server/fn_missions_zones_clearSites.sqf
+++ b/game/functions/systems/missions_zones/server/fn_missions_zones_clearSites.sqf
@@ -1,0 +1,38 @@
+/*
+    File: fn_missions_zones_clearSites.sqf
+    Author: Savage Game Design
+    Date: 2024-08-22
+    Last Update: 2024-08-24
+    Public: Yes
+
+    Description:
+        Clears all sites from a zone.
+
+    Parameter(s):
+        _targetZone - Zone to spawn sites in [STRING]
+
+    Returns:
+        None
+
+    Example(s):
+        ["oscar8"] call vgm_s_fnc_missions_zones_clearSites
+ */
+
+params ["_targetZone"];
+
+private _zoneSites = vgm_missions_zones_spawnedSites getOrDefault [_targetZone, [], true];
+
+// Delete everything from 0 to the current max index.
+// Go backwards, because:
+// - No newly added sites are deleted (i.e - no race condition)
+// - Better performance using deleteAt on the array.
+private _deleteIndex = count _zoneSites;
+
+while { _deleteIndex > 0 } do {
+    // Decrement first, in case there's an error later.
+    _deleteIndex = _deleteIndex - 1;
+    private _site = _zoneSites # _deleteIndex;
+    [_site] call vgm_s_fnc_sites_delete;
+
+    _zoneSites deleteAt _deleteIndex;
+};

--- a/game/functions/systems/missions_zones/server/fn_missions_zones_getSites.sqf
+++ b/game/functions/systems/missions_zones/server/fn_missions_zones_getSites.sqf
@@ -1,0 +1,23 @@
+/*
+    File: fn_missions_zones_getSites.sqf
+    Author:
+    Date: 2024-08-24
+    Last Update: 2024-08-24
+    Public: No
+
+    Description:
+        Returns an array of sites currently spawned in the named target box.
+
+    Parameter(s):
+        _targetZone - ID of the target zone [STRING]
+
+    Returns:
+        Array of sites [ARRAY]
+
+    Example(s):
+        ["oscar8"] call vgm_s_fnc_missions_zones_getSites;
+ */
+
+params ["_targetZone"];
+
+vgm_missions_zones_spawnedSites getOrDefault [_targetZone, []];

--- a/game/functions/systems/missions_zones/server/fn_missions_zones_preInit.sqf
+++ b/game/functions/systems/missions_zones/server/fn_missions_zones_preInit.sqf
@@ -2,7 +2,7 @@
     File: fn_missions_zones_preInit.sqf
     Author: Savage Game Design
     Date: 2024-03-20
-    Last Update: 2024-06-14
+    Last Update: 2024-08-22
     Public: No
 
     Description:
@@ -14,5 +14,7 @@ if (!isServer) exitWith {};
 vgm_missions_zones_lastSeed = -1;
 
 vgm_missions_zones_targetBoxesModifiers = createHashMap;
+
+vgm_missions_zones_spawnedSites = createHashMap;
 
 ["vgm_missions_zones_zoneReservations"] call para_s_fnc_netmap_createNamedNetmap;

--- a/game/functions/systems/missions_zones/server/fn_missions_zones_spawnRandomSites.sqf
+++ b/game/functions/systems/missions_zones/server/fn_missions_zones_spawnRandomSites.sqf
@@ -1,0 +1,69 @@
+/*
+    File: fn_missions_zones_spawnRandomSites.sqf
+    Author: Savage Game Design
+    Date: 2024-08-22
+    Last Update: 2024-08-29
+    Public: Yes
+
+    Description:
+        Spawns random sites in a zone, weighted by the zone's available slots.
+
+    Parameter(s):
+        _targetZone - Zone to spawn sites in [STRING]
+        _quantity - Number of sites to spawn [NUMBER]
+
+    Returns:
+        All spawned sites [ARRAY]
+
+    Example(s):
+        ["oscar8", 10] call vgm_s_fnc_missions_zones_spawnRandomSites;
+ */
+
+params ["_targetZone", "_quantity"];
+
+private _zoneSites = vgm_missions_zones_spawnedSites getOrDefault [_targetZone, [], true];
+
+private _locations = [_targetZone] call vgm_s_fnc_loc_getTargetBoxLocations;
+
+private _siteTypes = [] call vgm_s_fnc_sites_getAllSiteTypes;
+private _siteTypeIds = keys _siteTypes;
+private _siteWeights = _siteTypeIds apply {count (_locations getOrDefault [_x, []])};
+
+private _occupiedLocations = createHashMap;
+private _createdSites = [];
+
+for "_i" from 1 to _quantity do {
+    private _chosenSiteId = "";
+    private _siteLocations = [];
+    private _siteSelectionAttempts = 0;
+    while { count _siteLocations isEqualTo 0 && _siteSelectionAttempts < 3 } do {
+        _siteSelectionAttempts = _siteSelectionAttempts + 1;
+        _chosenSiteId = _siteTypeIds selectRandomWeighted _siteWeights;
+        _siteLocations = _locations getOrDefault [_chosenSiteId, []];
+    };
+
+    // If we didn't find a valid site, just continue with the next spawning attempt.
+    if (_siteLocations isEqualTo []) then {
+        continue;
+    };
+
+    private _chosenLocation = selectRandom _siteLocations;
+    private _locationAttempts = 0;
+    while { _chosenLocation in _occupiedLocations && _locationAttempts < 3 } do {
+        _locationAttempts = _locationAttempts + 1;
+        _chosenLocation = selectRandom _siteLocations;
+    };
+
+    if (_chosenLocation in _occupiedLocations) then {
+        continue;
+    };
+
+    _occupiedLocations set [_chosenLocation, true];
+
+    private _createdSite = [_chosenSiteId, _chosenLocation] call vgm_s_fnc_sites_spawn;
+    // Add to _zoneSites as sites are spawned. That way if a later spawn errors, earlier sites can be cleaned up.
+    _zoneSites pushBack _createdSite;
+    _createdSites pushBack _createdSite;
+};
+
+_createdSites

--- a/game/functions/systems/sites/server/fn_sites_delete.sqf
+++ b/game/functions/systems/sites/server/fn_sites_delete.sqf
@@ -2,7 +2,7 @@
     File: sites_delete.sqf
     Author: Savage Game Design
     Date: 2024-05-25
-    Last Update: 2024-05-25
+    Last Update: 2024-08-24
     Public: Yes
 
     Description:
@@ -21,6 +21,7 @@
 
 params ["_site"];
 
+[_site] call (_site get "type" getOrDefault ["cleanupFunction", {}]);
 
 {
     [_x] call vgm_s_fnc_sites_delete;

--- a/game/functions/systems/sites/server/fn_sites_getTemplate.sqf
+++ b/game/functions/systems/sites/server/fn_sites_getTemplate.sqf
@@ -4,7 +4,7 @@
     File: sites_getTemplate.sqf
     Author: Savage Game Design
     Date: 2024-05-25
-    Last Update: 2024-08-22
+    Last Update: 2024-08-24
     Public: Yes
 
     Description:
@@ -27,6 +27,8 @@ createHashMapFromArray [
     ["size", SITE_FOOTPRINT_SMALL],
     // Location requirements. List of tags that need to be met for a spawn location to be valid.
     ["locRequirements", []],
+    // Whether to hide nearby trees and rocks
+    ["hideNearbyTerrain", true],
     // Called to spawn the site.
     ["spawnFunction", {
         params ["_pos2D"];

--- a/game/functions/systems/sites/server/fn_sites_getTemplate.sqf
+++ b/game/functions/systems/sites/server/fn_sites_getTemplate.sqf
@@ -38,6 +38,11 @@ createHashMapFromArray [
             ["objects", []]
         ]
     }],
+    // Called to cleanup the site, before objects are despawned.
+    ["cleanupFunction", {
+        // params ["_site"];
+        // Do things
+    }],
     ["fortifications", [
         /*
         createHashMapFromArray [

--- a/game/functions/systems/sites/server/fn_sites_getTemplate.sqf
+++ b/game/functions/systems/sites/server/fn_sites_getTemplate.sqf
@@ -4,7 +4,7 @@
     File: sites_getTemplate.sqf
     Author: Savage Game Design
     Date: 2024-05-25
-    Last Update: 2024-07-04
+    Last Update: 2024-08-22
     Public: Yes
 
     Description:
@@ -32,7 +32,9 @@ createHashMapFromArray [
         params ["_pos2D"];
 
         // Format: [ [ All Objects Created ] ]
-        [[]]
+        createHashMapFromArray [
+            ["objects", []]
+        ]
     }],
     ["fortifications", [
         /*

--- a/game/functions/systems/sites/server/fn_sites_preInit.sqf
+++ b/game/functions/systems/sites/server/fn_sites_preInit.sqf
@@ -1,8 +1,10 @@
+#include "../sites.inc"
+
 /*
     File: sites_preInit.sqf
     Author: Savage Game Design
     Date: 2024-05-25
-    Last Update: 2024-07-27
+    Last Update: 2024-08-24
     Public: No
 
     Description:
@@ -25,6 +27,12 @@ private _siteTypesMap = localNamespace getVariable "vgm_s_sites_siteTypes";
 if (isNil "_siteTypesMap") then {
     localNamespace setVariable ["vgm_s_sites_siteTypes", createHashMap];
 };
+
+vgm_s_sites_siteRadii = createHashMapFromArray [
+    [SITE_FOOTPRINT_SMALL, SITE_FOOTPRINT_SMALL_RADIUS],
+    [SITE_FOOTPRINT_MEDIUM, SITE_FOOTPRINT_MEDIUM_RADIUS],
+    [SITE_FOOTPRINT_LARGE, SITE_FOOTPRINT_LARGE_RADIUS]
+];
 
 [] call vgm_s_fnc_sites_loadSiteTypesFromConfig;
 

--- a/game/functions/systems/sites/server/fn_sites_spawn.sqf
+++ b/game/functions/systems/sites/server/fn_sites_spawn.sqf
@@ -1,8 +1,10 @@
+#include "../sites.inc"
+
 /*
     File: sites_spawn.sqf
     Author: Savage Game Design
     Date: 2024-05-25
-    Last Update: 2024-08-15
+    Last Update: 2024-08-24
     Public: Yes
 
     Description:
@@ -27,6 +29,20 @@ private _siteType = localNamespace getVariable "vgm_s_sites_siteTypes" get _type
 
 if (isNil "_siteType") exitWith {
     [format ["Failed to spawn unknown site '%1'", _typeId]] call vgm_g_fnc_logError;
+};
+
+if (_siteType getOrDefault ["hideNearbyTerrain", false]) then {
+    private _radius = (vgm_s_sites_siteRadii getOrDefault [_siteType get "size", SITE_FOOTPRINT_LARGE_RADIUS]);
+    private _nearbyTerrain = nearestTerrainObjects [
+        _pos2D,
+        ["SMALL TREE", "TREE", "HIDE"],
+        _radius,
+        false,
+        true
+    ];
+    {
+        _x hideObjectGlobal true;
+    } forEach _nearbyTerrain;
 };
 
 private _spawnResult = [_pos2D] call (_siteType get "spawnFunction");

--- a/game/functions/systems/sites/sites.inc
+++ b/game/functions/systems/sites/sites.inc
@@ -1,6 +1,9 @@
-// Small footprint - 10m x 10m area
+// Small footprint - 10m x 10m area, 5m radius
 #define SITE_FOOTPRINT_SMALL "small"
-// Medium footprint - 20m x 20m area
+#define SITE_FOOTPRINT_SMALL_RADIUS 5
+// Medium footprint - 20m x 20m area, 10m radius
 #define SITE_FOOTPRINT_MEDIUM "medium"
-// Large footprint - 50m x 50m area
+#define SITE_FOOTPRINT_MEDIUM_RADIUS 10
+// Large footprint - 50m x 50m area, 25m radius
 #define SITE_FOOTPRINT_LARGE "large"
+#define SITE_FOOTPRINT_LARGE_RADIUS 25

--- a/game/functions/systems/sites/types/server/fn_sites_type_ammoCache.sqf
+++ b/game/functions/systems/sites/types/server/fn_sites_type_ammoCache.sqf
@@ -34,7 +34,7 @@ _site set ["locRequirements", []];
 _site set ["spawnFunction", {
     params ["_pos2D"];
 
-    private _composition = [["Land_vn_pavn_weapons_stack2",[-0.789063,-0.753174],-0.00256729,-0.00572395,[0.951401,0.307952,0.00123082],[0,-0.00399675,0.999992],1,0,"",true,true,false],["Land_vn_pavn_weapons_stack1",[-0.271729,0.984131],-0.00221062,-0.00329781,[-0.0460609,0.998939,0.000184095],[0.00399675,0,0.999992],1,0,"",true,true,false],["Land_vn_pavn_weapons_stack3",[1.06006,-0.231689],-0.00117683,0.0030632,[0,1,0],[0.00399675,0,0.999992],1,0,"",true,true,false]];
+    private _composition = [["Land_vn_pavn_weapons_stack2",[-0.789063,-0.753174],-0.00256729,-0.00572395,[0.951401,0.307952,0.00123082],[0,-0.00399675,0.999992],1,0,"",true,true,true],["Land_vn_pavn_weapons_stack1",[-0.271729,0.984131],-0.00221062,-0.00329781,[-0.0460609,0.998939,0.000184095],[0.00399675,0,0.999992],1,0,"",true,true,true],["Land_vn_pavn_weapons_stack3",[1.06006,-0.231689],-0.00117683,0.0030632,[0,1,0],[0.00399675,0,0.999992],1,0,"",true,true,true]];
     private _objects = [_pos2D + [0], 0, _composition] call vgm_g_fnc_objGrabber_map;
 
     createHashMapFromArray [

--- a/game/functions/systems/sites/types/server/fn_sites_type_ammoCache.sqf
+++ b/game/functions/systems/sites/types/server/fn_sites_type_ammoCache.sqf
@@ -4,7 +4,7 @@
     File: fn_sites_types_ammoCache.sqf
     Author: Savage Game Design
     Date: 2024-06-27
-    Last Update: 2024-08-15
+    Last Update: 2024-08-24
     Public: Yes
 
     Description:

--- a/game/functions/systems/sites/types/server/fn_sites_type_campfire.sqf
+++ b/game/functions/systems/sites/types/server/fn_sites_type_campfire.sqf
@@ -4,7 +4,7 @@
     File: fn_sites_types_shelter.sqf
     Author: Savage Game Design
     Date: 2024-06-27
-    Last Update: 2024-07-04
+    Last Update: 2024-08-22
     Public: Yes
 
     Description:
@@ -35,7 +35,9 @@ _campFire set ["spawnFunction", {
 
     private _campFire = createVehicle ["Land_Campfire_F", [_pos2D # 0, _pos2D # 1, 0], [], 0, "NONE"];
 
-    [[ _campFire ]]
+    createHashMapFromArray [
+        ["objects", [ _campFire ]]
+    ]
 }];
 
 _campFire get "fortifications" pushBack createHashMapFromArray [

--- a/game/functions/systems/sites/types/server/fn_sites_type_shelter.sqf
+++ b/game/functions/systems/sites/types/server/fn_sites_type_shelter.sqf
@@ -4,7 +4,7 @@
     File: fn_sites_types_shelter.sqf
     Author: Savage Game Design
     Date: 2024-06-27
-    Last Update: 2024-07-04
+    Last Update: 2024-08-22
     Public: Yes
 
     Description:
@@ -35,7 +35,9 @@ _shelter set ["spawnFunction", {
 
     private _shelter = createVehicle ["Land_vn_o_shelter_03", [_pos2D # 0, _pos2D # 1, 0], [], 0, "NONE"];
 
-    [[ _shelter ]]
+    createHashMapFromArray [
+        ["objects", [ _shelter ]]
+    ]
 }];
 
 _shelter

--- a/game/functions/systems/sites/types/server/fn_sites_type_shelter.sqf
+++ b/game/functions/systems/sites/types/server/fn_sites_type_shelter.sqf
@@ -4,7 +4,7 @@
     File: fn_sites_types_shelter.sqf
     Author: Savage Game Design
     Date: 2024-06-27
-    Last Update: 2024-08-22
+    Last Update: 2024-08-24
     Public: Yes
 
     Description:
@@ -30,6 +30,7 @@ private _shelter = [] call vgm_s_fnc_sites_getTemplate;
 
 _shelter set ["name", "STR_VGM_SITES_SHELTER"];
 _shelter set ["size", SITE_FOOTPRINT_SMALL];
+_shelter set ["hideNearbyTerrain", false];
 _shelter set ["spawnFunction", {
     params ["_pos2D"];
 

--- a/game/functions/systems/sites/types/server/fn_sites_type_transmitter.sqf
+++ b/game/functions/systems/sites/types/server/fn_sites_type_transmitter.sqf
@@ -4,7 +4,7 @@
     File: fn_sites_types_transmitter.sqf
     Author: Savage Game Design
     Date: 2024-06-27
-    Last Update: 2024-08-15
+    Last Update: 2024-08-24
     Public: Yes
 
     Description:
@@ -31,6 +31,7 @@ private _site = [] call vgm_s_fnc_sites_getTemplate;
 _site set ["name", "STR_VGM_SITES_TRANSMITTER"];
 _site set ["size", SITE_FOOTPRINT_SMALL];
 _site set ["locRequirements", []];
+_site set ["hideNearbyTerrain", false];
 _site set ["spawnFunction", {
     params ["_pos2D"];
 

--- a/game/functions/systems/sites/types/server/fn_sites_type_truckPark.sqf
+++ b/game/functions/systems/sites/types/server/fn_sites_type_truckPark.sqf
@@ -4,7 +4,7 @@
     File: fn_sites_types_truckPark.sqf
     Author: Savage Game Design
     Date: 2024-06-27
-    Last Update: 2024-08-15
+    Last Update: 2024-08-24
     Public: Yes
 
     Description:
@@ -34,7 +34,7 @@ _site set ["locRequirements", ["covered", "near_road"]];
 _site set ["spawnFunction", {
     params ["_pos2D"];
 
-    private _composition = [["vn_o_wheeled_z157_fuel_nva65",[0,0],1.94047,1.94047,[0.298872,0.954293,0],[0,0,1],1,0,"",true,true,false]];
+    private _composition = [["vn_o_wheeled_z157_fuel_nva65",[0,0],1.94047,1.94047,[0.298872,0.954293,0],[0,0,1],1,0,"",true,true,true]];
     private _objects = [_pos2D + [0], 0, _composition] call vgm_g_fnc_objGrabber_map;
 
     createHashMapFromArray [


### PR DESCRIPTION
Enables random site spawning on mission start.

This currently just spawns the objects when the mission starts, and clears them up on mission end.

It doesn't change any AI spawning or behaviour.

There's also a few fixes in here for sites that were spawning underground.