### PR TITLE
Missions - Use terrain index for LZ location

### DIFF
--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_requestExtraction.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_requestExtraction.sqf
@@ -2,7 +2,7 @@
     File: fn_missions_gameplay_extraction_requestExtraction.sqf
     Author: Savage Game Design
     Date: 2024-05-23
-    Last Update: 2024-06-09
+    Last Update: 2024-11-07
     Public: No
 
     Description:
@@ -20,23 +20,7 @@
 
 params ["_player", ["_radio", objNull]];
 
-private _fnc_getLzPos = {
-    params ["_player", ["_attempts", 0]];
-
-    private _expression = "(3*meadow) + (1-trees) + (1-houses)";
-    private _places = selectBestPlaces [_player, 200, _expression, 25, 10];
-
-    if (_places isEqualTo [] && _attempts < 3) exitWith {
-        [_player, _attempts + 1] call _fnc_getLzPos // return
-    };
-
-    _places param [0, [getPosATL _player, -1]] select 0 // return
-};
-
-private _lzPosATL = _player call _fnc_getLzPos;
-_lzPosATL set [2, 0];
-
-[call vgm_c_fnc_missions_getCurrentMission get "id", _lzPosATL] remoteExecCall ["vgm_s_fnc_missions_gameplay_extraction_startExtract", 2];
+[call vgm_c_fnc_missions_getCurrentMission get "id"] remoteExecCall ["vgm_s_fnc_missions_gameplay_extraction_startExtract", 2];
 
 // dialog
 [_player, _radio] spawn {

--- a/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
+++ b/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
@@ -2,7 +2,7 @@
     File: fn_missions_gameplay_extraction_callExtract.sqf
     Author: Savage Game Design
     Date: 2023-11-24
-    Last Update: 2024-05-24
+    Last Update: 2024-11-07
     Public: No
 
     Description:
@@ -21,7 +21,8 @@
 
 params [
     "_missionId",
-    "_lzPosition",
+    ["_lzPosition", []],
+    ["_useExactLzPosition", false],
     ["_class", "vn_b_air_uh1d_02_07"],
     ["_distance", 3000],
     ["_originPos", markerPos "vgm_shared_hub"]
@@ -39,6 +40,25 @@ if (!(_playerGroup getVariable ["vgm_missions_extraction_canRequest", true])) ex
 };
 _playerGroup setVariable ["vgm_missions_extraction_canRequest", false, true];
 
+// Only doing this calculation serverside, as the client doesn't have target box location data.
+if (_lzPosition isEqualTo []) then {
+    private _targetBox = _mission get "public" get "targetZone";
+    private _lzs = ([_targetBox] call vgm_s_fnc_loc_getTargetBoxLocations) get "lz";
+    private _playerToExtract = leader _playerGroup;
+    if (isNull _playerToExtract) then {
+        _playerToExtract = selectRandom units _playerGroup;
+    };
+    private _lzsByDistance = _lzs apply {[_x distance2D _playerToExtract, _x]};
+    _lzsByDistance sort true;
+
+    _lzPosition = _lzsByDistance # 0 # 1;
+    _useExactLzPosition = true;
+};
+
+if (_lzPosition isEqualTo []) exitWith {
+    format ["Unable to extract, no LZ position found: %1", _missionId] call vgm_g_fnc_logError;
+};
+
 // spawn the helicopter, coming from the direction of the origin pos
 private _helicopter = [_class] call vgm_s_fnc_missions_gameplay_createCrewedHelicopter;
 
@@ -50,7 +70,7 @@ _helicopter setDir random 360;
 private _group = group _helicopter;
 
 private _safeLzPosition = _lzPosition findEmptyPosition [0, 100, _class];
-if (_safeLzPosition isEqualTo []) then {
+if (_useExactLzPosition || _safeLzPosition isEqualTo []) then {
     _safeLzPosition = _lzPosition;
 };
 


### PR DESCRIPTION
Not entirely happy with this implementation.

I'd rather we did the search in `requestExtraction` clientside, then sent that to the server.

However, terrain index currently only exists on the server (which in hindsight, was a mistake).

Rather than migrating the terrain index to be global in this PR, I figure we can do this for now and revisit this next time we come across a clientside need for the terrain index. 