### PR TITLE
Tutorial - Add basic framework

### DIFF
--- a/game/configs/config_mission.hpp
+++ b/game/configs/config_mission.hpp
@@ -3,6 +3,7 @@
 
 #include "cfg_artillery.hpp"
 #include "cfg_equipment.hpp"
+#include "cfg_field_manual.hpp"
 #include "cfg_levels.hpp"
 #include "cfg_site_types.hpp"
 #include "cfg_skills.hpp"

--- a/game/configs/mission/cfg_field_manual.hpp
+++ b/game/configs/mission/cfg_field_manual.hpp
@@ -1,0 +1,3 @@
+class CfgHints {
+    #include "cfg_tutorial.hpp"
+};

--- a/game/configs/mission/cfg_tutorial.hpp
+++ b/game/configs/mission/cfg_tutorial.hpp
@@ -1,6 +1,28 @@
 class Tutorial {
     displayName = "Tutorial";
 
+    /*
+    class Example {
+        displayName = "Example";
+        displayNameShort = "E.g.";
+        description = "This is an example of a triggerable tutorial.";
+        // image = "";
+
+        // Triggers cause the card hint to appear on-screen.
+        // A tutorial will only ever show a hint once, no matter how many times its triggered.
+        class Triggers {
+            // Fires when this marker in the mission.sqm is entered by the player.
+            markerEntered = "";
+            // Fires when this event is triggered on the client, from any source.
+            eventFired = "vgm_tutorial_test";
+            // Objects with a `vgm_c_tutorial` variable set can trigger a tutorial.
+            // E.g for this tutorial entry:
+            //     cursorObject setVariable ["vgm_c_tutorial", ["Tutorial", "Example"]];
+        };
+    };
+    */
+
+
     class Tutorial1 {
         displayName = "Tutorial 1";
         displayNameShort = "Tutorial 1";

--- a/game/configs/mission/cfg_tutorial.hpp
+++ b/game/configs/mission/cfg_tutorial.hpp
@@ -1,0 +1,45 @@
+class Tutorial {
+    displayName = "Tutorial";
+
+    class Tutorial1 {
+        displayName = "Tutorial 1";
+        displayNameShort = "Tutorial 1";
+        description = "This is an example of tutorial text to be used while setting the system up.";
+        // image = "";
+        // Note: No Image
+
+        class Triggers {
+            markerEntered = "";
+            eventFired = "vgm_tutorial_test";
+            // Objects with a `vgm_c_tutorial` variable set can also trigger.
+            // e.g cursorObject setVariable ["vgm_c_tutorial", ["Tutorial", "Tutorial1"]];
+        };
+    };
+
+    class Tutorial2 {
+        displayName = "Tutorial 2";
+        displayNameShort = "Tutorial 2";
+        description = "This is an example of tutorial text to be used while setting the system up.";
+        // image = "";
+        // Note: No Image
+
+        class Triggers {
+            markerEntered = "tutorial_2";
+            //eventFired = "";
+            // Objects with a `vgm_c_tutorial` variable set can also trigger.
+            // e.g cursorObject setVariable ["vgm_c_tutorial", ["Tutorial", "Tutorial1"]];
+        };
+    };
+};
+
+class Other {
+    displayName = "Other";
+
+    class Tutorial1 {
+        displayName = "Other 1";
+        displayNameShort = "Other 1";
+        description = "This is an example of tutorial text to be used while setting the system up.";
+        // image = "";
+        // Note: No Image
+    };
+};

--- a/game/configs/mission/ui/ui_main.hpp
+++ b/game/configs/mission/ui/ui_main.hpp
@@ -14,7 +14,7 @@
 #include "VGM_DisplayEndOfMission.hpp"
 
 import RscHealthTextures from RscTitles;
-class RscTitles
+class RscTitles : ParadigmRscTitles
 {
     #include "VGM_RscAbilityCooldown.hpp"
     #include "VGM_RscMedicalStatus.hpp"

--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -857,4 +857,20 @@ class vgm_c
             preInit = 1;
         };
     };
+
+    class tutorial
+    {
+        VGM_CLIENT_PATH(\systems\tutorial\client);
+
+        class tutorial_preInit
+        {
+            preInit = 1;
+        };
+        class tutorial_postInit
+        {
+            postInit = 1;
+        };
+
+        class tutorial_trigger {};
+    };
 };

--- a/game/functions/systems/tutorial/client/fn_tutorial_postInit.sqf
+++ b/game/functions/systems/tutorial/client/fn_tutorial_postInit.sqf
@@ -1,0 +1,60 @@
+/*
+    File: fn_tutorial_postInit.sqf
+    Author:
+    Date: 2024-11-16
+    Last Update: 2024-11-17
+    Public: No
+
+    Description:
+        PostInit for the tutorial system
+
+*/
+
+private _categories = configProperties [missionConfigFile >> "CfgHints", "isClass _x", true];
+
+{
+    private _categoryConfig = _x;
+    private _triggerableTutorials = configProperties [_categoryConfig, "isClass _x && (isClass (_x >> 'Triggers'))", true];
+    {
+        // Set up triggers for 'markerEntered' events.
+        // Can't be done in preInit, as we need `markerPos`, which is only ready in postInit (seemingly).
+        private _hintConfig = _x;
+        private _triggerConfig = _hintConfig >> "Triggers";
+        private _marker = getText (_triggerConfig >> "markerEntered");
+        if (_marker != "" && markerPos _marker isNotEqualTo [0, 0, 0]) then {
+            _marker setMarkerAlphaLocal 0;
+            private _trigger = createTrigger ["EmptyDetector", markerPos _marker, false];
+            _trigger setTriggerActivation ["ANYPLAYER", "PRESENT", true];
+            private _markerSize = markerSize _marker;
+            _trigger setTriggerArea [_markerSize # 0, _markerSize # 1, markerDir _marker, markerShape _marker isEqualTo "RECTANGLE"];
+            _trigger setTriggerStatements [
+                "this && player in thisList",
+                format ["['%1', '%2'] call vgm_c_fnc_tutorial_trigger;", configName _categoryConfig, configName _hintConfig],
+                ""
+            ];
+        };
+
+        // Create a global subscription for an event.
+        // This might need tweaking if events on other clients start triggering local tutorials.
+        private _event = getText (_triggerConfig >> "eventFired");
+        if (_event != "") then {
+            [
+                _event,
+                [
+                    [configName _categoryConfig, configName _hintConfig], {
+                        params ["_args", "_savedArgs"];
+                        _savedArgs call vgm_c_fnc_tutorial_trigger;
+                    }
+                ]
+            ] call para_g_fnc_event_subscribe;
+        };
+    } forEach _triggerableTutorials;
+} forEach _categories;
+
+// Watch for objects with vgm_c_tutorial set.
+addMissionEventHandler ["EachFrame", {
+    private _target = cursorObject;
+    private _tutorial = cursorObject getVariable "vgm_c_tutorial";
+    if (isNil "_tutorial" || { _target distance2D player > 4 }) exitWith {};
+    [_tutorial # 0, _tutorial # 1] call vgm_c_fnc_tutorial_trigger;
+}];

--- a/game/functions/systems/tutorial/client/fn_tutorial_postInit.sqf
+++ b/game/functions/systems/tutorial/client/fn_tutorial_postInit.sqf
@@ -28,7 +28,7 @@ private _categories = configProperties [missionConfigFile >> "CfgHints", "isClas
             private _markerSize = markerSize _marker;
             _trigger setTriggerArea [_markerSize # 0, _markerSize # 1, markerDir _marker, markerShape _marker isEqualTo "RECTANGLE"];
             _trigger setTriggerStatements [
-                "this && player in thisList",
+                "player in thisList",
                 format ["['%1', '%2'] call vgm_c_fnc_tutorial_trigger;", configName _categoryConfig, configName _hintConfig],
                 ""
             ];

--- a/game/functions/systems/tutorial/client/fn_tutorial_preInit.sqf
+++ b/game/functions/systems/tutorial/client/fn_tutorial_preInit.sqf
@@ -12,6 +12,7 @@
 
 */
 
+if (!hasInterface) exitWith {};
 [] call para_c_fnc_ui_hints_setup;
 
 [

--- a/game/functions/systems/tutorial/client/fn_tutorial_preInit.sqf
+++ b/game/functions/systems/tutorial/client/fn_tutorial_preInit.sqf
@@ -1,0 +1,30 @@
+#include "\a3\ui_f\hpp\defineDIKCodes.inc"
+
+/*
+    File: fn_tutorial_preInit.sqf
+    Author:
+    Date: 2024-11-16
+    Last Update: 2024-11-17
+    Public: No
+
+    Description:
+        PreInit for the tutorial system
+
+*/
+
+[] call para_c_fnc_ui_hints_setup;
+
+[
+    createHashMapFromArray [
+        ["name", "TutorialAcknowledgeHint"],
+        ["displayName", "STR_VGM_TUTORIAL_UI_ACKNOWLEDGE_HINT"],
+        ["onRelease", false],
+        ["defaultKey", createHashMapFromArray [
+            ["dikCode", DIK_8]
+        ]]
+    ]
+] call para_c_fnc_keyhandler_registerAction;
+["TutorialAcknowledgeHint", para_c_fnc_ui_hints_acknowledgeHintKeypress] call para_c_fnc_keyhandler_addGeneralActionHandler;
+
+// Ideally store this on the server.
+vgm_c_tutorial_seenTutorials = missionProfileNamespace getVariable ["vgm_tutorial_seenTutorials", createHashMap];

--- a/game/functions/systems/tutorial/client/fn_tutorial_trigger.sqf
+++ b/game/functions/systems/tutorial/client/fn_tutorial_trigger.sqf
@@ -1,0 +1,30 @@
+/*
+    File: fn_tutorial_trigger.sqf
+    Author: Savage Game Design
+    Date: 2024-11-17
+    Last Update: 2024-11-17
+    Public: Yes
+
+    Description:
+        Makes the given tutorial appear.
+
+    Parameter(s):
+        _category - Tutorial category [STRING]
+        _tutorialName - Name of the tutorial [STRING]
+
+    Returns:
+        Nothing
+
+    Example(s):
+        ["Tutorial", "Tutorial1"] call vgm_c_fnc_tutorial_trigger;
+ */
+
+params ["_category", "_tutorialName"];
+
+private _key = [_category, _tutorialName];
+
+if (_key in vgm_c_tutorial_seenTutorials) exitWith {};
+
+[_category, _tutorialName] call para_c_fnc_ui_hints_show_hint;
+
+vgm_c_tutorial_seenTutorials set [_key, true];

--- a/game/mission/stringtable.xml
+++ b/game/mission/stringtable.xml
@@ -523,4 +523,9 @@
             <English>Scout the area for enemy sites and note them in your "Scouting Report".&lt;br/&gt;&lt;br/&gt;HQ suggests checking following grids:&lt;br/&gt;%1</English>
         </Key>
     </Package>
+    <Package name="Tutorial">
+        <Key ID="STR_VGM_TUTORIAL_UI_ACKNOWLEDGE_HINT">
+            <English>Acknowledge Hint</English>
+        </Key>
+    </Package>
 </Project>


### PR DESCRIPTION
Adds support for CfgHints entries to show as a survival card hint, when triggered by one of these conditions:
- Entering a specific marker on the map
- The client receiving a specific event from any source
- Looking at an object with `vgm_c_tutorial` set to the path of the tutorial.