### PR TITLE
Advanced Hints - Crude fix for 2x8 not opening field manual when no hint is showing

### DIFF
--- a/paradigm/client/functions/ui/survival_hints/fn_ui_hints_acknowledgeHintKeypress.sqf
+++ b/paradigm/client/functions/ui/survival_hints/fn_ui_hints_acknowledgeHintKeypress.sqf
@@ -16,10 +16,12 @@
 		[] call para_c_fnc_ui_hints_acknowledgeHint
 */
 
+
 // Double press behaviour
 
 private _doublePressTime = 0.2;
 private _lastKeypress = localNamespace getVariable ["para_c_ui_hints_last_acknowledge_keypress", 0];
+localNamespace setVariable ["para_c_ui_hints_last_acknowledge_keypress", time];
 
 if (time < _lastKeypress + _doublePressTime) exitWith {
   private _lastHint = localNamespace getVariable "para_c_ui_hints_last_acknowledged_hint";
@@ -38,7 +40,6 @@ if (count _activeHints <= 0) exitWith {
 };
 
 localnamespace setVariable ["para_c_ui_hints_last_acknowledged_hint", _activeHints select 0];
-localNamespace setVariable ["para_c_ui_hints_last_acknowledge_keypress", time];
 
 [] call para_c_fnc_ui_hints_pop_hint;
 


### PR DESCRIPTION
It's not ideal - but ideal would involve reworking how the keyhandler processes events, so we could get good double-tap detection.

As-is, this still fires single-press behaviour when firing double-press behaviour. But it's better than it was.
