### PR TITLE
Squad UI - Fix icons vanishing at high zoom

### DIFF
--- a/game/functions/systems/squad_ui/client/fn_squad_ui_drawPlayersOnMapEventHandler.sqf
+++ b/game/functions/systems/squad_ui/client/fn_squad_ui_drawPlayersOnMapEventHandler.sqf
@@ -2,7 +2,7 @@
     File: fn_squad_ui_drawPlayersOnMapEventHandler.sqf
     Author: Savage Game Design
     Date: 2024-11-06
-    Last Update: 2024-11-06
+    Last Update: 2024-11-30
     Public: No
 
     Description:
@@ -17,6 +17,8 @@
     Example(s):
         _ctrlMap addEventHandler ["Draw", vgm_c_fnc_squad_ui_drawPlayersOnMapEventHander];
  */
+
+#define FONT_SIZE 0.042
 
 params ["_ctrlMap"];
 

--- a/game/functions/systems/squad_ui/client/fn_squad_ui_postInit.sqf
+++ b/game/functions/systems/squad_ui/client/fn_squad_ui_postInit.sqf
@@ -2,7 +2,7 @@
     File: fn_squad_ui_postInit.sqf
     Author: Savage Game Design
     Date: 2024-07-04
-    Last Update: 2024-11-09
+    Last Update: 2024-11-30
     Public: No
 
     Description:
@@ -88,7 +88,6 @@ call {
 
 // map indicators
 call {
-    #define FONT_SIZE 0.042
     #define CTRL_MAP (findDisplay 12 displayCtrl 51)
 
     vgm_squad_ui_playerColor = playerSide call BIS_fnc_sideColor;


### PR DESCRIPTION
The font size define was not moved over when it was refactored into a function