### PR TITLE
Focus - Add enable buffer time, refactor

### DIFF
--- a/game/functions/core/global/fn_preInit.sqf
+++ b/game/functions/core/global/fn_preInit.sqf
@@ -2,7 +2,7 @@
     File: fn_preInit.sqf
     Author: Savage Game Design
     Date: 2022-11-13
-    Last Update: 2025-02-03
+    Last Update: 2025-02-24
     Public: No
 
     Description:
@@ -11,5 +11,30 @@
 
 vgm_version = localize "STR_VGM_MISSION_VERSION";
 
-vgm_core_waitUntilAndExecute_eh = -1;
-vgm_core_waitUntilAndExecute_array = [];
+// init WUAE system
+call {
+    #define REMOVE_ITEM vgm_core_waitUntilAndExecute_array deleteAt _forEachIndex;
+
+    vgm_core_waitUntilAndExecute_eh = -1;
+    vgm_core_waitUntilAndExecute_array = [];
+
+    vgm_core_waitUntilAndExecute_eh = addMissionEventHandler ["EachFrame", {
+        {
+            _x params ["_condition", "_code", "_args", "_timeoutTime", "_timeoutCode"];
+            // if _timeoutDelay is nil this will be not be executed due to how SQF operators work
+            if (time > _timeoutTime) then {
+                _args call _timeoutCode;
+
+                REMOVE_ITEM;
+                continue;
+            };
+
+            if (_args call _condition) then {
+                _args call _code;
+
+                REMOVE_ITEM;
+                continue;
+            };
+        } forEachReversed vgm_core_waitUntilAndExecute_array;
+    }];
+};

--- a/game/functions/core/global/fn_preInit.sqf
+++ b/game/functions/core/global/fn_preInit.sqf
@@ -2,7 +2,7 @@
     File: fn_preInit.sqf
     Author: Savage Game Design
     Date: 2022-11-13
-    Last Update: 2023-06-30
+    Last Update: 2025-02-03
     Public: No
 
     Description:
@@ -11,3 +11,5 @@
 
 vgm_version = localize "STR_VGM_MISSION_VERSION";
 
+vgm_core_waitUntilAndExecute_eh = -1;
+vgm_core_waitUntilAndExecute_array = [];

--- a/game/functions/core/global/fn_waitUntilAndExecute.sqf
+++ b/game/functions/core/global/fn_waitUntilAndExecute.sqf
@@ -1,0 +1,61 @@
+/*
+    File: fn_waitUntilAndExecute.sqf
+    Author: Savage Game Design
+    Date: 2025-02-02
+    Last Update: 2025-02-03
+    Public: No
+
+    Description:
+        No description added yet.
+
+    Parameter(s):
+        N/A
+
+    Returns:
+        Something [BOOL]
+
+    Example(s):
+        [parameter] call vgm_X_fnc_component_myFunction
+ */
+
+#define REMOVE_ITEM vgm_core_waitUntilAndExecute_array deleteAt _forEachIndex;
+
+params [
+    ["_condition", {true}, [{}]],
+    ["_code", {}, [{}]],
+    ["_args", []],
+    ["_timeoutDelay", nil, [0]],
+    ["_timeoutCode", {}, [{}]]
+];
+
+if (vgm_core_waitUntilAndExecute_eh == -1) then {
+    private _eh = addMissionEventHandler ["EachFrame", {
+        {
+            _x params ["_condition", "_code", "_args", "_timeoutTime", "_timeoutCode"];
+            // if _timeoutDelay is nil this will be not be executed due to how SQF operators work
+            if (time > _timeoutTime) then {
+                _args call _timeoutCode;
+
+                REMOVE_ITEM;
+                continue;
+            };
+
+            if (_args call _condition) then {
+                _args call _code;
+
+                REMOVE_ITEM;
+                continue;
+            };
+        } forEachReversed vgm_core_waitUntilAndExecute_array;
+
+        if (vgm_core_waitUntilAndExecute_array isEqualTo []) then {
+            // we could consider having the EachFrame run all the time to prevent constant increments of the EH ids
+            removeMissionEventHandler ["EachFrame", _thisEventHandler];
+            vgm_core_waitUntilAndExecute_eh = -1;
+        };
+    }];
+
+    vgm_core_waitUntilAndExecute_eh = _eh;
+};
+
+vgm_core_waitUntilAndExecute_array pushBack [_condition, _code, _args, time + _timeoutDelay, _timeoutCode];

--- a/game/functions/core/global/fn_waitUntilAndExecute.sqf
+++ b/game/functions/core/global/fn_waitUntilAndExecute.sqf
@@ -3,19 +3,29 @@
     Author: Savage Game Design
     Date: 2025-02-02
     Last Update: 2025-02-03
-    Public: No
+    Public: Yes
 
     Description:
-        No description added yet.
+        Executes provided code unscheduled once the condition is true, optionally can have a timeout and code executed upon the timeout.
 
     Parameter(s):
-        N/A
+        _condition - Callback to call for condition check [CODE]
+        _code - Callback to execute once condition is true [CODE]
+        _args - Arguments to pass to all callbacks [ANY]
+        _timeoutDelay - How long to wait for the timeout [NUMBER]
+        _timeoutCode - Callback to call on timeout [CODE]
 
     Returns:
-        Something [BOOL]
+        Nothing
 
     Example(s):
-        [parameter] call vgm_X_fnc_component_myFunction
+        [
+            {speed (_this#0) < 1},
+            {systemChat "standing still"},
+            [player],
+            5,
+            {systemChat "please stand still!"}
+        ] call vgm_g_fnc_waitUntilAndExecute;
  */
 
 #define REMOVE_ITEM vgm_core_waitUntilAndExecute_array deleteAt _forEachIndex;
@@ -59,3 +69,5 @@ if (vgm_core_waitUntilAndExecute_eh == -1) then {
 };
 
 vgm_core_waitUntilAndExecute_array pushBack [_condition, _code, _args, time + _timeoutDelay, _timeoutCode];
+
+nil

--- a/game/functions/core/global/fn_waitUntilAndExecute.sqf
+++ b/game/functions/core/global/fn_waitUntilAndExecute.sqf
@@ -2,7 +2,7 @@
     File: fn_waitUntilAndExecute.sqf
     Author: Savage Game Design
     Date: 2025-02-02
-    Last Update: 2025-02-03
+    Last Update: 2025-02-24
     Public: Yes
 
     Description:
@@ -28,8 +28,6 @@
         ] call vgm_g_fnc_waitUntilAndExecute;
  */
 
-#define REMOVE_ITEM vgm_core_waitUntilAndExecute_array deleteAt _forEachIndex;
-
 params [
     ["_condition", {true}, [{}]],
     ["_code", {}, [{}]],
@@ -37,36 +35,6 @@ params [
     ["_timeoutDelay", nil, [0]],
     ["_timeoutCode", {}, [{}]]
 ];
-
-if (vgm_core_waitUntilAndExecute_eh == -1) then {
-    private _eh = addMissionEventHandler ["EachFrame", {
-        {
-            _x params ["_condition", "_code", "_args", "_timeoutTime", "_timeoutCode"];
-            // if _timeoutDelay is nil this will be not be executed due to how SQF operators work
-            if (time > _timeoutTime) then {
-                _args call _timeoutCode;
-
-                REMOVE_ITEM;
-                continue;
-            };
-
-            if (_args call _condition) then {
-                _args call _code;
-
-                REMOVE_ITEM;
-                continue;
-            };
-        } forEachReversed vgm_core_waitUntilAndExecute_array;
-
-        if (vgm_core_waitUntilAndExecute_array isEqualTo []) then {
-            // we could consider having the EachFrame run all the time to prevent constant increments of the EH ids
-            removeMissionEventHandler ["EachFrame", _thisEventHandler];
-            vgm_core_waitUntilAndExecute_eh = -1;
-        };
-    }];
-
-    vgm_core_waitUntilAndExecute_eh = _eh;
-};
 
 vgm_core_waitUntilAndExecute_array pushBack [_condition, _code, _args, time + _timeoutDelay, _timeoutCode];
 

--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -29,6 +29,7 @@ class vgm_g
         class startScheduler {
             postInit = 1;
         };
+        class waitUntilAndExecute {};
     };
 
     class debug

--- a/game/functions/systems/skill_investigate/client/fn_skill_investigate_preInit.sqf
+++ b/game/functions/systems/skill_investigate/client/fn_skill_investigate_preInit.sqf
@@ -4,7 +4,7 @@
     File: fn_skill_investigate_postInit.sqf
     Author: Savage Game Design
     Date: 2024-01-17
-    Last Update: 2025-01-06
+    Last Update: 2025-02-03
     Public: No
 
     Description:
@@ -14,6 +14,7 @@
 if (!hasInterface) exitWith {};
 
 vgm_c_skill_investigate_intensity = 0;
+vgm_c_skill_investigate_isFocusing = false;
 
 [
     createHashMapFromArray [

--- a/game/functions/systems/skill_investigate/client/fn_skill_investigate_setFocusMode.sqf
+++ b/game/functions/systems/skill_investigate/client/fn_skill_investigate_setFocusMode.sqf
@@ -1,8 +1,8 @@
 /*
     File: fn_skill_investigate_setFocusMode.sqf
-    Author:
+    Author: Savage Game Design
     Date: 2025-01-05
-    Last Update: 2025-01-09
+    Last Update: 2025-02-04
     Public: No
 
     Description:
@@ -23,35 +23,39 @@
 
 params ["_enable"];
 
-private _isFocusing = missionNamespace getVariable ["vgm_c_skill_investigate_isFocusing", false];
-
-if (_enable && !_isFocusing && (call vgm_c_fnc_skill_investigate_canFocus)) exitWith {
-    player playActionNow "Stop";
-    [true] call vgm_c_fnc_skill_investigate_setDesaturation;
-    [true] call vgm_c_fnc_skill_investigate_setListenMode;
-    vgm_c_skill_investigate_isFocusing = true;
-    vgm_c_skill_investigate_focusPFEH = addMissionEventHandler ["EachFrame", {
-        if (call vgm_c_fnc_skill_investigate_canFocus) exitWith {};
-
-        // This should remove the event handler.
-        [false] call vgm_c_fnc_skill_investigate_setFocusMode;
-    }];
-};
-
-
-if (!_enable && _isFocusing) exitWith {
-    if (!(call vgm_c_fnc_skill_investigate_canFocus)) then {
-        hint localize "STR_VGM_SKILL_INVESTIGATE_NOTIFICATION_STATIONARY";
-        playSoundUI ["\a3\ui_f_curator\Data\Sound\CfgSound\error02.wss", 0.1];
-    };
-
-    [false] call vgm_c_fnc_skill_investigate_setDesaturation;
-    [false] call vgm_c_fnc_skill_investigate_setListenMode;
-
-    if (!isNil "vgm_c_skill_investigate_focusPFEH") then {
-        removeMissionEventHandler ["EachFrame", vgm_c_skill_investigate_focusPFEH];
-        vgm_c_skill_investigate_focusPFEH = nil;
-    };
-
+if (!_enable) exitWith {
     vgm_c_skill_investigate_isFocusing = false;
 };
+
+if (vgm_c_skill_investigate_isFocusing) exitWith {};
+vgm_c_skill_investigate_isFocusing = true;
+
+[
+    {call vgm_c_fnc_skill_investigate_canFocus},
+    {
+        [true] call vgm_c_fnc_skill_investigate_setDesaturation;
+        [true] call vgm_c_fnc_skill_investigate_setListenMode;
+
+        // check if player can remain focused
+        [
+            {
+                !vgm_c_skill_investigate_isFocusing
+                || !(call vgm_c_fnc_skill_investigate_canFocus)
+            },
+            {
+                vgm_c_skill_investigate_isFocusing = false;
+                [false] call vgm_c_fnc_skill_investigate_setDesaturation;
+                [false] call vgm_c_fnc_skill_investigate_setListenMode;
+            },
+            _this
+        ] call vgm_g_fnc_waitUntilAndExecute;
+    },
+    nil,
+    0.4,
+    {
+        if (!vgm_c_skill_investigate_isFocusing) exitWith {};
+        vgm_c_skill_investigate_isFocusing = false;
+        hint localize "STR_VGM_SKILL_INVESTIGATE_NOTIFICATION_STATIONARY";
+        playSoundUI ["\a3\ui_f_curator\Data\Sound\CfgSound\error02.wss", 0.1];
+    }
+] call vgm_g_fnc_waitUntilAndExecute;

--- a/game/functions/systems/skill_investigate/client/fn_skill_investigate_setFocusMode.sqf
+++ b/game/functions/systems/skill_investigate/client/fn_skill_investigate_setFocusMode.sqf
@@ -31,7 +31,9 @@ if (vgm_c_skill_investigate_isFocusing) exitWith {};
 vgm_c_skill_investigate_isFocusing = true;
 
 [
+    // Condition to wait for
     {call vgm_c_fnc_skill_investigate_canFocus},
+    // Code to execute
     {
         [true] call vgm_c_fnc_skill_investigate_setDesaturation;
         [true] call vgm_c_fnc_skill_investigate_setListenMode;
@@ -50,8 +52,11 @@ vgm_c_skill_investigate_isFocusing = true;
             _this
         ] call vgm_g_fnc_waitUntilAndExecute;
     },
+    // Arguments
     nil,
+    // Timeout
     0.4,
+    // Code executed on timeout
     {
         if (!vgm_c_skill_investigate_isFocusing) exitWith {};
         vgm_c_skill_investigate_isFocusing = false;


### PR DESCRIPTION
- 0.4s buffer time while checking for "canFocus"
- Addition of `waitUntilAndExecute` function with same API as [CBA](https://cbateam.github.io/CBA_A3/docs/files/common/fnc_waitUntilAndExecute-sqf.html) one
- Refactor of Focus loop to utilise `waitUntilAndExecute`
- "Error" hint/sound is not played anymore when focus is disabled due to movement, only when unable to enable due to movement, IMO it's bit better as hearing the error sound every time you break focus by moving is annoying