### PR TITLE
Adds `posIndex_getItems`

### DIFF
--- a/game/functions/core/global/position_index/fn_posindex_add.sqf
+++ b/game/functions/core/global/position_index/fn_posindex_add.sqf
@@ -2,7 +2,7 @@
     File: fn_posindex_add.sqf
     Author: Savage Game Design
     Date: 2025-01-09
-    Last Update: 2025-01-24
+    Last Update: 2025-03-01
     Public: Yes
 
     Description:
@@ -28,9 +28,11 @@ if (count _vacantSlots > 0) exitWith {
     private _slot = _vacantSlots deleteAt 0;
     _index get "positions" set [_slot, _pos];
     _index get "items" set [_slot, _item];
+    _index get "itemsMap" set [_slot, _item];
     _slot
 };
 private _slot = _index get "positions" pushBack _pos;
 _index get "items" set [_slot, _item];
+_index get "itemsMap" set [_slot, _item];
 
 _slot

--- a/game/functions/core/global/position_index/fn_posindex_create.sqf
+++ b/game/functions/core/global/position_index/fn_posindex_create.sqf
@@ -2,7 +2,7 @@
     File: fn_posindex_create.sqf
     Author: Savage Game Design
     Date: 2025-01-09
-    Last Update: 2025-01-24
+    Last Update: 2025-03-01
     Public: Yes
 
     Description:
@@ -44,15 +44,19 @@ private _positions = [];
 private _indexes = [];
 // Shallow copy to avoid external systems interfering with our array
 private _itemsCopy = [] + _items;
+private _itemsMap = createHashMap;
 
 {
     _positions pushBack (_x call _fnc_getItemPos);
     _indexes pushBack _forEachIndex;
+    _itemsMap set [_forEachIndex, _x];
 } forEach _itemsCopy;
 
 private _posIndex = createHashMapFromArray [
     ["positions", _positions],
     ["items", _itemsCopy],
+    // HashMaps can be sparse. Enables us to get all items without any nils.
+    ["itemsMap", _itemsMap],
     ["vacantSlots", []],
     ["getItemPos", _fnc_getItemPos]
 ];

--- a/game/functions/core/global/position_index/fn_posindex_deleteAt.sqf
+++ b/game/functions/core/global/position_index/fn_posindex_deleteAt.sqf
@@ -2,7 +2,7 @@
     File: fn_posindex_deleteAt.sqf
     Author: Savage Game Design
     Date: 2025-01-09
-    Last Update: 2025-01-10
+    Last Update: 2025-03-01
     Public: Yes
 
     Description:
@@ -23,6 +23,7 @@ params ["_index", "_slot"];
 
 _index get "positions" set [_slot, nil];
 _index get "items" set [_slot, nil];
+_index get "itemsMap" deleteAt _slot;
 _index get "vacantSlots" pushBack _slot;
 
 nil

--- a/game/functions/core/global/position_index/fn_posindex_getItems.sqf
+++ b/game/functions/core/global/position_index/fn_posindex_getItems.sqf
@@ -1,0 +1,23 @@
+/*
+    File: fn_posindex_get.sqf
+    Author: Savage Game Design
+    Date: 2025-01-09
+    Last Update: 2025-03-01
+    Public: Yes
+
+    Description:
+        Gets all items in the posIndex, with no order guarantees.
+
+    Parameter(s):
+        _index - Index to query [HASHMAP]
+
+    Returns:
+        All items [ARRAY]
+
+    Example(s):
+        [_index] call vgm_g_fnc_posindex_getItems;
+ */
+
+params ["_index"];
+
+values (_index get "itemsMap")

--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -41,6 +41,7 @@ class vgm_g
         class posindex_delete {};
         class posindex_deleteAt {};
         class posindex_get {};
+        class posindex_getItems {};
         class posindex_inAreaArray {};
         class posindex_inAreaArrayIndexes {};
         class posindex_refreshAllItems {};


### PR DESCRIPTION
Provides a way to get all the items from a position index, without any `nil` entries that are caused by items being deleted from the index.

Not currently needed - but I did all the thinking on this, so thought I'd add it just in case. 