### PR TITLE
Builds: Launched processes interruptible from shell.

### DIFF
--- a/build/run.py
+++ b/build/run.py
@@ -8,6 +8,8 @@ from vgm.build import OutputFolderExistsError, calculate_mission_output_paths, P
 import vgm.field_manual
 import vgm.file_mapping
 import vgm.arma
+from time import sleep
+
 
 source_root = Path(__file__).parent.parent
 
@@ -30,7 +32,7 @@ def default_build_params(output_paths=output_paths, overwrite: bool = False, cle
     return params
 
 def launch_arma(connect: str = "", editor_mission_path: Path = None):
-    vgm.arma.launch(
+    return vgm.arma.launch(
         arma_exe_path=Path(config.arma_exe_path),
         mods=config.arma_arg_mods,
         args=config.arma_args,
@@ -39,7 +41,7 @@ def launch_arma(connect: str = "", editor_mission_path: Path = None):
     )
 
 def launch_arma_server(mod: bool = False):
-    vgm.arma.launch_server(
+    return vgm.arma.launch_server(
         arma_server_exe=Path(config.arma_exe_path),
         mission_path=Path(mission_paths[0]),
         config=Path(config.arma_server_config_path),
@@ -76,6 +78,15 @@ def command_launch_arma_server(mod):
     launch_arma_server(mod)
 
 
+def check_terminate_process(process):
+    returncode = process.poll()
+    if returncode is None:
+        process.terminate()
+
+    returncode = process.wait(15)
+    if returncode is None:
+        process.kill()
+
 @click.command
 @option_overwrite
 @option_clean
@@ -111,10 +122,29 @@ def command_launch_dev(overwrite, clean, mod, version, no_server, no_client):
     perform_build(default_build_params(overwrite=overwrite, clean=clean, as_mod=mod, version=version))
 
     if not no_server:
-        launch_arma_server(mod)
+        server_process = launch_arma_server(mod)
 
     if not no_client:
-        launch_arma(connect="127.0.0.1")
+        client_process = launch_arma(connect="127.0.0.1")
+
+    try:
+        while (
+            server_process.returncode is None
+            and client_process.returncode is None
+        ):
+            sleep(5)
+
+    except KeyboardInterrupt:
+        check_terminate_process(server_process)
+        check_terminate_process(client_process)
+
+    except BaseException as err:
+        print(f"An unknown error occured: {err}")
+
+    else:
+        print("An Arma process terminated outside of build. Killing any remaining processes.")
+        check_terminate_process(server_process)
+        check_terminate_process(client_process)
 
 @click.command
 @click.option('--confirm', default=False, is_flag=True)

--- a/build/run.py
+++ b/build/run.py
@@ -7,8 +7,8 @@ import vgm.build
 from vgm.build import OutputFolderExistsError, calculate_mission_output_paths, PackType, BuildParams
 import vgm.field_manual
 import vgm.file_mapping
+from vgm.processes import process_handler
 import vgm.arma
-from time import sleep
 
 
 source_root = Path(__file__).parent.parent
@@ -57,6 +57,10 @@ def perform_build(params: BuildParams = default_build_params()):
         print(f"Output folder '{e.path}' already exists. If you wish to overwrite it, use --overwrite")
         raise
 
+option_interrupt = click.option('--interrupt', default=False, is_flag=True,
+                                help="Interruption of launched Arma client/server processes managed by CLI")
+option_interrupt_polling = click.option('--polling', default=1, is_flag=False, type=int,
+                                help="Process interruption polling duration (seconds)")
 option_overwrite = click.option('--overwrite', default=False, is_flag=True)
 option_clean = click.option('--clean', default=False, is_flag=True)
 option_mod = click.option('--mod', default=False, is_flag=True, help="Builds VGM to run as a client / server mod pair")
@@ -67,25 +71,23 @@ option_version = click.option('--version', default=None,
 @click.command("client")
 @click.option('--connect', default=None)
 @click.option('--editor', is_flag=True)
-def command_launch_arma_client(connect, editor):
+@option_interrupt
+@option_interrupt_polling
+def command_launch_arma_client(connect, editor, interrupt, polling):
     editor_mission_path = mission_paths[0] if editor else None
-    launch_arma(connect, editor_mission_path=editor_mission_path)
+    process = launch_arma(connect, editor_mission_path=editor_mission_path)
+    if interrupt:
+        process_handler([process], polling_seconds=polling)
 
 
 @click.command("server")
 @click.option('--mod', default=False, is_flag=True)
-def command_launch_arma_server(mod):
-    launch_arma_server(mod)
-
-
-def check_terminate_process(process):
-    returncode = process.poll()
-    if returncode is None:
-        process.terminate()
-
-    returncode = process.wait(15)
-    if returncode is None:
-        process.kill()
+@option_interrupt
+@option_interrupt_polling
+def command_launch_arma_server(mod, interrupt, polling):
+    process = launch_arma_server(mod)
+    if interrupt:
+        process_handler([process], polling_seconds=polling)
 
 @click.command
 @option_overwrite
@@ -118,7 +120,9 @@ def build(overwrite, clean, mod, dev, pack, version):
               help="Doesn't start an arma server")
 @click.option('--no-client', default=False, is_flag=True,
               help="Doesn't start an arma client")
-def command_launch_dev(overwrite, clean, mod, version, no_server, no_client):
+@option_interrupt
+@option_interrupt_polling
+def command_launch_dev(overwrite, clean, mod, version, no_server, no_client, interrupt, polling):
     perform_build(default_build_params(overwrite=overwrite, clean=clean, as_mod=mod, version=version))
 
     if not no_server:
@@ -127,24 +131,8 @@ def command_launch_dev(overwrite, clean, mod, version, no_server, no_client):
     if not no_client:
         client_process = launch_arma(connect="127.0.0.1")
 
-    try:
-        while (
-            server_process.returncode is None
-            and client_process.returncode is None
-        ):
-            sleep(5)
-
-    except KeyboardInterrupt:
-        check_terminate_process(server_process)
-        check_terminate_process(client_process)
-
-    except BaseException as err:
-        print(f"An unknown error occured: {err}")
-
-    else:
-        print("An Arma process terminated outside of build. Killing any remaining processes.")
-        check_terminate_process(server_process)
-        check_terminate_process(client_process)
+    if interrupt:
+        process_handler([server_process, client_process], polling_seconds=polling)
 
 @click.command
 @click.option('--confirm', default=False, is_flag=True)

--- a/build/vgm/arma.py
+++ b/build/vgm/arma.py
@@ -48,7 +48,7 @@ def launch(arma_exe_path, mods=[], args=[], connect=False, editor_mission_path: 
     print(f"Launching Arma: {list(map(str, command))}")
 
     # start arma
-    subprocess.Popen(command)
+    return subprocess.Popen(command)
 
 def launch_server(mission_path: Path, arma_server_exe: Path, config: Path, servermod_path=None, mods=[], profile="vgm_server"):
     try_symlink_arma_server_mission_dir(mission_path, arma_server_exe)
@@ -56,16 +56,16 @@ def launch_server(mission_path: Path, arma_server_exe: Path, config: Path, serve
     server_config_path = setup_temporary_arma_server_config(config, mission_path.name)
 
     if servermod_path:
-        hemtt.launch(
+        return hemtt.launch(
             servermod_path,
             arma_args=[
                 f"-name={profile}",
                 f"-config={server_config_path}"
             ]
         )
-        return
 
-    launch(
+
+    return launch(
         arma_exe_path=arma_server_exe,
         mods=mods,
         args=[

--- a/build/vgm/hemtt.py
+++ b/build/vgm/hemtt.py
@@ -18,7 +18,7 @@ def launch(path: Path, args=[], arma_args=[]):
 
     print(f"Launching HEMTT: {command}")
 
-    return subprocess.run(command, cwd=path)
+    return subprocess.Popen(command, cwd=path)
 
 def dev(path: Path, args=[]):
     command = [

--- a/build/vgm/processes.py
+++ b/build/vgm/processes.py
@@ -15,6 +15,8 @@ def check_terminate_process(process: Popen, timeout: int = 15):
         - process: a `subprocess.Popen` process
         - timeout: number of seconds to wait for process termination before
           sending a SIGKILL
+
+    Returns: None
     """
     if process.returncode is not None:
         print(f"Process already exited: {process.returncode}")
@@ -34,6 +36,11 @@ def check_terminate_process(process: Popen, timeout: int = 15):
 def check_alive(process: Popen):
     """
     Check if a process is still alive.
+
+    Args:
+    	- process: a `subprocess.Popen` object
+
+    Returns: `True` when process is alive, `False` when process has exited
     """
     return process.poll() is None
 
@@ -49,6 +56,7 @@ def process_handler(processes: List[Popen], polling_seconds: int = 1):
 
     Args:
         - processes: list of subprocess.Popen objects
+        - polling_seconds: check alive-ness of all processes every X seconds
 
     Notes:
         capturing SIGINT annoyingly needs try-except for branch logic :/
@@ -56,6 +64,8 @@ def process_handler(processes: List[Popen], polling_seconds: int = 1):
         could use `signal.signal()`, but means mutating some process tracking
         object/variable in global namespace (more complicated script state etc)
         https://stackoverflow.com/a/4205386/5945794
+
+    Returns: None
     """
 
     try:

--- a/build/vgm/processes.py
+++ b/build/vgm/processes.py
@@ -7,7 +7,19 @@ from time import sleep
 from typing import List
 
 
-def check_terminate_process(process: Popen, timeout: int = 15):
+def check_alive(process: Popen):
+    """
+    Check if a process is still alive.
+
+    Args:
+    	- process: a `subprocess.Popen` object
+
+    Returns: `True` when process is alive, `False` when process has exited
+    """
+    return process.poll() is None
+
+
+def terminate_process(process: Popen, timeout: int = 15):
     """
     Terminate/kill a process. Kills if not exited after specified timeout.
 
@@ -31,18 +43,6 @@ def check_terminate_process(process: Popen, timeout: int = 15):
     if returncode is None:
         print(f"Process still alive after {timeout} seconds, SIGKILL: pid={process.pid}")
         process.kill()
-
-
-def check_alive(process: Popen):
-    """
-    Check if a process is still alive.
-
-    Args:
-    	- process: a `subprocess.Popen` object
-
-    Returns: `True` when process is alive, `False` when process has exited
-    """
-    return process.poll() is None
 
 
 def process_handler(processes: List[Popen], polling_seconds: int = 1):
@@ -83,4 +83,4 @@ def process_handler(processes: List[Popen], polling_seconds: int = 1):
 
     finally:
         for p in processes:
-            check_terminate_process(p)
+            terminate_process(p)

--- a/build/vgm/processes.py
+++ b/build/vgm/processes.py
@@ -1,0 +1,76 @@
+"""
+Process management utility functions.
+"""
+
+from subprocess import Popen
+from time import sleep
+from typing import List
+
+
+def check_terminate_process(process: Popen, timeout: int = 15):
+    """
+    Terminate/kill a process. Kills if not exited after specified timeout.
+
+    Args:
+        - process: a `subprocess.Popen` process
+        - timeout: number of seconds to wait for process termination before
+          sending a SIGKILL
+    """
+    if process.returncode is not None:
+        print(f"Process already exited: {process.returncode}")
+        return
+
+    returncode = process.poll()
+    if returncode is None:
+        print(f"Attempting SIGTERM: pid={process.pid}")
+        process.terminate()
+
+    returncode = process.wait(timeout)
+    if returncode is None:
+        print(f"Process still alive after {timeout} seconds, SIGKILL: pid={process.pid}")
+        process.kill()
+
+
+def check_alive(process: Popen):
+    """
+    Check if a process is still alive.
+    """
+    return process.poll() is None
+
+
+def process_handler(processes: List[Popen], polling_seconds: int = 1):
+    """
+    Manages launched processes, terminating/killing running processes when
+
+    1. SIGINT recevied (Ctrl + C)
+    2. a process is killed externally (externally killing server process will
+      terminate still running client process)
+    3. some error occurs while processes are running (bug in CLI)
+
+    Args:
+        - processes: list of subprocess.Popen objects
+
+    Notes:
+        capturing SIGINT annoyingly needs try-except for branch logic :/
+
+        could use `signal.signal()`, but means mutating some process tracking
+        object/variable in global namespace (more complicated script state etc)
+        https://stackoverflow.com/a/4205386/5945794
+    """
+
+    try:
+        while all(check_alive(x) for x in processes):
+            sleep(polling_seconds)
+
+    except KeyboardInterrupt:
+        print("Interrupt!")
+
+    except BaseException as err:
+        print(f"An unknown error occured: {err}")
+
+    else:
+        print("A process was terminated externally. Terminating any remaining processes.")
+
+    finally:
+        for p in processes:
+            check_terminate_process(p)


### PR DESCRIPTION
Adds `--interrupt` and `--polling` options to `launch` command group.

When `--interrupt` is provided, CLI will track the state of launched processes and will interrupt them when:
* SIGINT received (Ctrl +C in shell)
* at least one of the processes has exited (quitting the sever manually will quit the client)
* some error occurred when managing the process (unlikely, but there as an edge case)

`--polling` can be used to set the polling duration of checking process state (seconds)