### PR TITLE
chore: add build_logs directory to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/__pycache__
 
 output/**
+build_logs/**


### PR DESCRIPTION
Stops `build_logs` directory from being committed in future.