### PR TITLE
Build: 'Fix' windows path handling for server config argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Copy `build/arma_server.example.hpp` to `build/arma_server.hpp`, and add your St
 It's recommended to set the mission output folder to your Arma 3 profile's `mpmissions` folder.
 
 #### Required software
-- Python (3.12 or later)
+- Python (3.12 or later, must be windows MSC python[^0])
 - HEMTT (On windows: winget hemtt)
 
 ### Running the build
@@ -103,6 +103,4 @@ The server commands will also:
 
 For further details on build script commands, run `python3 build/run.py --help`. 
 
-
-
-
+[^0]: GCC python builds, such as those distributed by MSYS2's pacman, utilise posix paths and break the build scripts.

--- a/build/vgm/arma.py
+++ b/build/vgm/arma.py
@@ -1,8 +1,28 @@
 import subprocess
 import sgd.file_utils
 from pathlib import Path
+from sys import platform
 
 from . import hemtt
+
+
+def maybe_fix_win_path(path: Path):
+    """
+    Fix path borkage for Arma CLI args on Windows
+
+    Notes:
+        Arma requires file path CLI arguments look exactly like this:
+        `DRIVE:\DIR\DIR\DIR\FILENAME.EXT`
+
+        `pathlib.Path` reprs to `DRIVE:/DIR/DIR/FIR/FILENAME.EXT`, which
+        Arma's CLI won't recognise as a valid Windows path. Escaped paths
+        a la `DRIVE:\\DIR\\DIR\\DIR\\FILENAME.EXT` also do not work.
+
+        If you're tweaking the arma_server.hpp configuration file and the
+        builder CLI is not updating your server with new configuration options,
+        this is probably your exact problem.
+    """
+    return f"{path}".replace("/", "\\") if platform in ["win32", "cygwin"] else path
 
 def find_mpmissions(search_start: Path) -> Path | None:
     def is_mpmissions(path: Path) -> bool:
@@ -53,7 +73,9 @@ def launch(arma_exe_path, mods=[], args=[], connect=False, editor_mission_path: 
 def launch_server(mission_path: Path, arma_server_exe: Path, config: Path, servermod_path=None, mods=[], profile="vgm_server"):
     try_symlink_arma_server_mission_dir(mission_path, arma_server_exe)
 
-    server_config_path = setup_temporary_arma_server_config(config, mission_path.name)
+    server_config_path = maybe_fix_win_path(
+        setup_temporary_arma_server_config(config, mission_path.name)
+    )
 
     if servermod_path:
         hemtt.launch(

--- a/build/vgm/arma.py
+++ b/build/vgm/arma.py
@@ -7,7 +7,7 @@ from . import hemtt
 
 
 def maybe_fix_win_path(path: Path):
-    """
+    r"""
     Fix path borkage for Arma CLI args on Windows
 
     Notes:
@@ -15,8 +15,7 @@ def maybe_fix_win_path(path: Path):
         `DRIVE:\DIR\DIR\DIR\FILENAME.EXT`
 
         `pathlib.Path` reprs to `DRIVE:/DIR/DIR/FIR/FILENAME.EXT`, which
-        Arma's CLI won't recognise as a valid Windows path. Escaped paths
-        a la `DRIVE:\\DIR\\DIR\\DIR\\FILENAME.EXT` also do not work.
+        Arma's CLI won't recognise as a valid Windows path.
 
         If you're tweaking the arma_server.hpp configuration file and the
         builder CLI is not updating your server with new configuration options,

--- a/build/vgm/arma.py
+++ b/build/vgm/arma.py
@@ -6,22 +6,33 @@ from sys import platform
 from . import hemtt
 
 
-def maybe_fix_win_path(path: Path):
+class UnixPathException(Exception):
     r"""
-    Fix path borkage for Arma CLI args on Windows
-
-    Notes:
-        Arma requires file path CLI arguments look exactly like this:
-        `DRIVE:\DIR\DIR\DIR\FILENAME.EXT`
-
-        `pathlib.Path` reprs to `DRIVE:/DIR/DIR/FIR/FILENAME.EXT`, which
-        Arma's CLI won't recognise as a valid Windows path.
-
-        If you're tweaking the arma_server.hpp configuration file and the
-        builder CLI is not updating your server with new configuration options,
-        this is probably your exact problem.
+    Exception when a variable uses a unix `/` delimited path instead of
+    windows `\` delimited.
     """
-    return f"{path}".replace("/", "\\") if platform in ["win32", "cygwin"] else path
+    def __init__(self, path: Path):
+        self.path = path
+
+    def __str__(self):
+        return rf"Possible unix `/` path detected where an explicit windows `\` path required: path={self.path}"
+
+
+def validate_windows_path(path: Path):
+    r"""
+    Require a windows `\` delimited path in windows terminal environments.
+
+    GCC python defaults to `/` paths, while MSC python defaults to `\` paths.
+    Arma requires `\` delimited paths for CLI options like server config etc.
+    i.e. `DRIVE:\DIR\DIR\DIR\FILENAME.EXT`
+
+    Throws an error for an invalid path.
+    """
+    if "/" in str(path) and platform in ["win32", "cygwin"]:
+        raise UnixPathException(path)
+    else:
+        return path
+
 
 def find_mpmissions(search_start: Path) -> Path | None:
     def is_mpmissions(path: Path) -> bool:
@@ -72,7 +83,7 @@ def launch(arma_exe_path, mods=[], args=[], connect=False, editor_mission_path: 
 def launch_server(mission_path: Path, arma_server_exe: Path, config: Path, servermod_path=None, mods=[], profile="vgm_server"):
     try_symlink_arma_server_mission_dir(mission_path, arma_server_exe)
 
-    server_config_path = maybe_fix_win_path(
+    server_config_path = validate_windows_path(
         setup_temporary_arma_server_config(config, mission_path.name)
     )
 


### PR DESCRIPTION
Caveat: This may be a "@dijksterhuis is using a weird terminal environment" problem.

----

When trying to run `python3 ./build/run.py launch dev --overwrite` or `python3 ./build/run.py launch server` in a MSYS2 (MGWIN64) shell, the launched arma server refuses to load the generated server configuration file. Which then means battleye is enabled and all sorts.

`pathlib.Path` paths in an MSYS2 environment are actually `pathlib.WindowsPath`s under the hood. But when the path is represented in an f-string, python outputs forward slashes.

For the path to the arma executables etc, this is fine. however, Arma CLI args require proper non-posix windows path structure a la `DRIVE:\DIR\DIR\DIR\FILENAME.EXT` ..... i.e. only backslashes.