### PR TITLE
Sites: Fix site load completed logging line.

### DIFF
--- a/game/functions/systems/sites/server/fn_sites_loadSiteTypesFromConfig.sqf
+++ b/game/functions/systems/sites/server/fn_sites_loadSiteTypesFromConfig.sqf
@@ -45,4 +45,4 @@ private _rootConfigs = [
 } forEach _rootConfigs;
 
 
-["%1 site types loaded", count (localNamespace getVariable "vgm_s_sites_siteTypes")] call vgm_g_fnc_logInfo;
+format ["%1 site types loaded", count (localNamespace getVariable "vgm_s_sites_siteTypes")] call vgm_g_fnc_logInfo;


### PR DESCRIPTION
Previous output

```
17:37:58 2025-7-31 16:37:58:195 | VGM | INFO | File: vgm_s_fnc_sites_loadSiteTypesFromConfig | Called By: vgm_s_fnc_sites_preInit | | %1 site types loaded
```

now:

```
17:58:23 2025-7-31 16:58:23:125 | VGM | INFO | File: vgm_s_fnc_sites_loadSiteTypesFromConfig | Called By: vgm_s_fnc_sites_preInit | | 8 site types loaded
```