### PR TITLE
Builds: Switch default hemtt DLC branch to mainline.

### DIFF
--- a/mod/server/.hemtt/launch.toml
+++ b/mod/server/.hemtt/launch.toml
@@ -1,8 +1,12 @@
 [default]
 workshop = [
-    "1649778181" # VN testing build
+    # Uncomment the below line to use the VN testing build
+    # (Make sure to disable the 'vn'` option in `dlc` attribute if you do)
+    # "1649778181"
 ]
-dlc = []
+dlc = [
+    "vn"
+]
 optionals = []
 parameters = [
 ]


### PR DESCRIPTION
Moving towards release -- other people generally won't have VN testing build installed.

Causes "mod not found" errors when starting a server.