### PR TITLE
Extract: Allow team leader to force extract via timer/immediate.

### DIFF
--- a/game/configs/mission/cfg_notifications.hpp
+++ b/game/configs/mission/cfg_notifications.hpp
@@ -40,4 +40,20 @@ class CfgNotifications
         description = "$STR_VGM_MISSIONS_SCOUTING_NOTIFICATION_SITE_CHANGED_PHOTO_DESCRIPTION";
     };
 
+    class VGM_ExtractionEvacNow: VGM_Default
+    {
+        title = "$STR_VGM_MISSIONS_EXTRACTION_NOTIFICATION_TITLE";
+        iconPicture = "\a3\ui_f\data\Map\Markers\Military\warning_ca.paa";
+        description = "$STR_VGM_MISSIONS_EXTRACTION_NOTIFICATION_EVACNOW_DESCRIPTION";
+        color[] = {0.8,0,0,1};
+    };
+
+    class VGM_ExtractionEvacAt: VGM_Default
+    {
+        title = "$STR_VGM_MISSIONS_EXTRACTION_NOTIFICATION_TITLE";
+        iconPicture = "\a3\ui_f\data\Map\Markers\Military\warning_ca.paa";
+        description = "$STR_VGM_MISSIONS_EXTRACTION_NOTIFICATION_EVACAT_DESCRIPTION";
+        color[] = {0.8,0,0,1};
+    };
+
 };

--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -569,7 +569,9 @@ class vgm_c
     {
         VGM_CLIENT_PATH(\systems\missions_gameplay\client\extraction);
 
-        class missions_gameplay_extraction_addAction {};
+        class missions_gameplay_extraction_addAction_requestExtract {};
+        class missions_gameplay_extraction_addAction_evacNow {};
+        class missions_gameplay_extraction_addAction_evacAt {};
         class missions_gameplay_extraction_requestExtraction {};
         class missions_gameplay_extraction_getNearbyRadio {};
     };

--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacAt.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacAt.sqf
@@ -8,8 +8,6 @@
     Description:
         Add action to request early extraction -- abandoning any players left on the ground.
 
-        TODO: Penalty for each player left behind.
-
     Parameter(s):
         _player - Player to add the action to [OBJECT]
 
@@ -23,7 +21,6 @@
 params ["_player"];
 
 
-// TODO: Check explicitly for extract helicopter?
 private _fnc_timedLeave = {
     params ["_target"];
 

--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacAt.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacAt.sqf
@@ -2,7 +2,7 @@
     File: fn_missions_gameplay_extraction_addAction_evaNow.sqf
     Author: Savage Game Design
     Date: 2024-05-23
-    Last Update: 2024-06-09
+    Last Update: 2025-08-24
     Public: No
 
     Description:
@@ -24,22 +24,24 @@ params ["_player"];
 private _fnc_timedLeave = {
     params ["_target"];
 
+    private _helicopter = (group _target) getVariable ["vgm_missions_extraction_helicopter", objNull];
     private _radio = _target call vgm_c_fnc_missions_gameplay_extraction_getNearbyRadio;
+    private _inHelicopter = objectParent _target isEqualTo _helicopter;
 
-    if (isNull _radio) exitWith {
-        hint localize "STR_VGM_MISSIONS_EXTRACTION_REQUEST_NO_RADIO";
+    if (!_inHelicopter && isNull _radio) exitWith {
+        hintSilent localize "STR_VGM_MISSIONS_EXTRACTION_EXTRACT_NO_RADIO";
         playSoundUI ["3DEN_notificationWarning", 0.5];
     };
 
     // hide action menu
     showCommandingMenu "RscGroupRootMenu"; showCommandingMenu "";
 
-    [_target, _radio] spawn {
-        params ["_target", "_radio"];
+    [_target, _helicopter] spawn {
+        params ["_target", "_helicopter"];
         sleep 0.5;
-        if (["Start Extraction countdown? Team will have 30 seconds to board the extraction helo ...", "Confirm", true, true] call BIS_fnc_guiMessage) then {
+        if ([localize "STR_VGM_MISSIONS_EXTRACTION_CONFIRM_TIMED_EXTRACTION", "Confirm", true, true] call BIS_fnc_guiMessage) then {
             // setting variable on helicopter breaks out of the spawn checking for all group members boarded
-            (objectParent _target) setVariable ["vgm_missions_extraction_evacAt", serverTime + 30, true];
+            _helicopter setVariable ["vgm_missions_extraction_evacAt", serverTime + 30, true];
             ["VGM_ExtractionEvacAt", []] remoteExec ["BIS_fnc_showNotification", units (group _target)];
         };
     };
@@ -54,18 +56,21 @@ private _actionId = [
     toString {
         vgm_mission_onMission
         // is group leader
-        && leader _target == _target
+        && {leader _target == _target}
+        && {
+            private _helicopter = (group _target) getVariable ["vgm_missions_extraction_helicopter", objNull];
+            // extraction helicopter exists
+            !isNull _helicopter
+            // helicopter landed
+            && _helicopter getVariable ["vgm_missions_extractionLanded", false]
+            // forced extract action not run yet
+            && {!(_helicopter getVariable ["vgm_missions_extraction_evacNow", false])}
+            // forced timer extract action not run
+            && {(_helicopter getVariable ["vgm_missions_extraction_evacAt", -1]) isEqualTo -1}
+        }
         // should not be possible to request extraction
-        && {!((group _target) getVariable ["vgm_missions_extraction_canRequest", true])}
-        // group leader is in vehicle
-        && {!isNull (objectParent _target)}
         // see: fn_missions_gameplay_extraction_startExtract.sqf
-        // group leader in extraction helo
-        && {(objectParent _target) == ((group _target) getVariable ["vgm_missions_extraction_helicopter", objNull])}
-        // forced extract action not run yet
-        && {!((objectParent _target) getVariable ["vgm_missions_extraction_evacNow", false])}
-        // forced timer extract action not run
-        && {((objectParent _target) getVariable ["vgm_missions_extraction_evacAt", -1]) isEqualTo -1}
+        && {!((group _target) getVariable ["vgm_missions_extraction_canRequest", true])}
     },
     "true",
     {},

--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacAt.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacAt.sqf
@@ -81,7 +81,7 @@ private _actionId = [
     1,
     100,
     false,
-    false,
+    true,
     false
 ] call BIS_fnc_holdActionAdd;
 

--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacAt.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacAt.sqf
@@ -1,0 +1,88 @@
+/*
+    File: fn_missions_gameplay_extraction_addAction_evaNow.sqf
+    Author: Savage Game Design
+    Date: 2024-05-23
+    Last Update: 2024-06-09
+    Public: No
+
+    Description:
+        Add action to request early extraction -- abandoning any players left on the ground.
+
+        TODO: Penalty for each player left behind.
+
+    Parameter(s):
+        _player - Player to add the action to [OBJECT]
+
+    Returns:
+        Action ID [Number]
+
+    Example(s):
+        [player] call vgm_c_fnc_missions_gameplay_extraction_addAction_evacNow
+ */
+
+params ["_player"];
+
+
+// TODO: Check explicitly for extract helicopter?
+private _fnc_timedLeave = {
+    params ["_target"];
+
+    private _radio = _target call vgm_c_fnc_missions_gameplay_extraction_getNearbyRadio;
+
+    if (isNull _radio) exitWith {
+        hint localize "STR_VGM_MISSIONS_EXTRACTION_REQUEST_NO_RADIO";
+        playSoundUI ["3DEN_notificationWarning", 0.5];
+    };
+
+    // hide action menu
+    showCommandingMenu "RscGroupRootMenu"; showCommandingMenu "";
+
+    [_target, _radio] spawn {
+        params ["_target", "_radio"];
+        sleep 0.5;
+        if (["Start Extraction countdown? Team will have 30 seconds to board the extraction helo ...", "Confirm", true, true] call BIS_fnc_guiMessage) then {
+            // setting variable on helicopter breaks out of the spawn checking for all group members boarded
+            (objectParent _target) setVariable ["vgm_missions_extraction_evacAt", serverTime + 30, true];
+            ["VGM_ExtractionEvacAt", []] remoteExec ["BIS_fnc_showNotification", units (group _target)];
+        };
+    };
+};
+
+
+private _actionId = [
+    _player,
+    localize "STR_VGM_MISSIONS_EXTRACTION_EVACTIMER_ACTION",
+    "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_takeOff2_ca.paa",
+    "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_takeOff2_ca.paa",
+    toString {
+        vgm_mission_onMission
+        // is group leader
+        && leader _target == _target
+        // should not be possible to request extraction
+        && {!((group _target) getVariable ["vgm_missions_extraction_canRequest", true])}
+        // group leader is in vehicle
+        && {!isNull (objectParent _target)}
+        // see: fn_missions_gameplay_extraction_startExtract.sqf
+        // group leader in extraction helo
+        && {(objectParent _target) == ((group _target) getVariable ["vgm_missions_extraction_helicopter", objNull])}
+        // forced extract action not run yet
+        && {!((objectParent _target) getVariable ["vgm_missions_extraction_evacNow", false])}
+        // forced timer extract action not run
+        && {((objectParent _target) getVariable ["vgm_missions_extraction_evacAt", -1]) isEqualTo -1}
+    },
+    "true",
+    {},
+    {},
+    _fnc_timedLeave,
+    {},
+    nil,
+    1,
+    100,
+    false,
+    false,
+    false
+] call BIS_fnc_holdActionAdd;
+
+_player setVariable ["vgm_missions_gameplay_extraction_action_evacAtStart", _actionId];
+
+_actionId // return

--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacNow.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacNow.sqf
@@ -8,8 +8,6 @@
     Description:
         Add action to request early extraction -- abandoning any players left on the ground.
 
-        TODO: Penalty for each player left behind.
-
     Parameter(s):
         _player - Player to add the action to [OBJECT]
 
@@ -23,7 +21,6 @@
 params ["_player"];
 
 
-// TODO: Check explicitly for extract helicopter?
 private _fnc_forceLeave = {
     params ["_target"];
 

--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacNow.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacNow.sqf
@@ -1,0 +1,87 @@
+/*
+    File: fn_missions_gameplay_extraction_addAction_evaNow.sqf
+    Author: Savage Game Design
+    Date: 2024-05-23
+    Last Update: 2024-06-09
+    Public: No
+
+    Description:
+        Add action to request early extraction -- abandoning any players left on the ground.
+
+        TODO: Penalty for each player left behind.
+
+    Parameter(s):
+        _player - Player to add the action to [OBJECT]
+
+    Returns:
+        Action ID [Number]
+
+    Example(s):
+        [player] call vgm_c_fnc_missions_gameplay_extraction_addAction_evacNow
+ */
+
+params ["_player"];
+
+
+// TODO: Check explicitly for extract helicopter?
+private _fnc_forceLeave = {
+    params ["_target"];
+
+    private _radio = _target call vgm_c_fnc_missions_gameplay_extraction_getNearbyRadio;
+
+    if (isNull _radio) exitWith {
+        hint localize "STR_VGM_MISSIONS_EXTRACTION_REQUEST_NO_RADIO";
+        playSoundUI ["3DEN_notificationWarning", 0.5];
+    };
+
+    // hide action menu
+    showCommandingMenu "RscGroupRootMenu"; showCommandingMenu "";
+
+    [_target, _radio] spawn {
+        sleep 0.5;
+        if (["Start Extraction Now? Remaining team members will be abandoned.", "Confirm", true, true] call BIS_fnc_guiMessage) then {
+            // setting variable on helicopter breaks out of the spawn checking for all group members boarded
+            (objectParent (_this select 0)) setVariable ["vgm_missions_extraction_evacNow", true, true];
+            ["VGM_ExtractionEvacNow", []] remoteExec ["BIS_fnc_showNotification", units (group (_this select 0))];
+
+        };
+    };
+};
+
+private _actionId = [
+    _player,
+    localize "STR_VGM_MISSIONS_EXTRACTION_EVACNOW_ACTION",
+    "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_takeOff2_ca.paa",
+    "\a3\ui_f\data\IGUI\Cfg\holdactions\holdAction_takeOff2_ca.paa",
+    toString {
+        vgm_mission_onMission
+        // is group leader
+        && leader _target == _target
+        // should not be possible to request extraction
+        && {!((group _target) getVariable ["vgm_missions_extraction_canRequest", true])}
+        // group leader is in vehicle
+        && {!isNull (objectParent _target)}
+        // see: fn_missions_gameplay_extraction_startExtract.sqf
+        // group leader in extraction helo
+        && {(objectParent _target) == ((group _target) getVariable ["vgm_missions_extraction_helicopter", objNull])}
+        // forced extract action not run yet
+        && {!((objectParent _target) getVariable ["vgm_missions_extraction_evacNow", false])}
+        // forced timer extract action not run
+        && {((objectParent _target) getVariable ["vgm_missions_extraction_evacAt", -1]) isEqualTo -1}
+    },
+    "true",
+    {},
+    {},
+    _fnc_forceLeave,
+    {},
+    nil,
+    1,
+    100,
+    false,
+    false,
+    false
+] call BIS_fnc_holdActionAdd;
+
+_player setVariable ["vgm_missions_gameplay_extraction_action_evacNowStart", _actionId];
+
+_actionId // return

--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacNow.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacNow.sqf
@@ -78,7 +78,7 @@ private _actionId = [
     1,
     100,
     false,
-    false,
+    true,
     false
 ] call BIS_fnc_holdActionAdd;
 

--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacNow.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacNow.sqf
@@ -2,7 +2,7 @@
     File: fn_missions_gameplay_extraction_addAction_evacNow.sqf
     Author: Savage Game Design
     Date: 2024-05-23
-    Last Update: 2024-06-09
+    Last Update: 2025-08-24
     Public: No
 
     Description:
@@ -24,23 +24,25 @@ params ["_player"];
 private _fnc_forceLeave = {
     params ["_target"];
 
+    private _helicopter = (group _target) getVariable ["vgm_missions_extraction_helicopter", objNull];
     private _radio = _target call vgm_c_fnc_missions_gameplay_extraction_getNearbyRadio;
+    private _inHelicopter = objectParent _target isEqualTo _helicopter;
 
-    if (isNull _radio) exitWith {
-        hint localize "STR_VGM_MISSIONS_EXTRACTION_REQUEST_NO_RADIO";
+    if (!_inHelicopter && isNull _radio) exitWith {
+        hintSilent localize "STR_VGM_MISSIONS_EXTRACT_NOW_NO_RADIO";
         playSoundUI ["3DEN_notificationWarning", 0.5];
     };
 
     // hide action menu
     showCommandingMenu "RscGroupRootMenu"; showCommandingMenu "";
 
-    [_target, _radio] spawn {
+    [_target, _helicopter] spawn {
+        params ["_target", "_helicopter"];
         sleep 0.5;
-        if (["Start Extraction Now? Remaining team members will be abandoned.", "Confirm", true, true] call BIS_fnc_guiMessage) then {
-            // setting variable on helicopter breaks out of the spawn checking for all group members boarded
-            (objectParent (_this select 0)) setVariable ["vgm_missions_extraction_evacNow", true, true];
-            ["VGM_ExtractionEvacNow", []] remoteExec ["BIS_fnc_showNotification", units (group (_this select 0))];
-
+        if ([localize "STR_VGM_MISSIONS_EXTRACTION_CONFIRM_IMMEDIATE_EXTRACTION", "Confirm", true, true] call BIS_fnc_guiMessage) then {
+            // Forces the extract check to pass immediately.
+            _helicopter setVariable ["vgm_missions_extraction_evacNow", true, true];
+            ["VGM_ExtractionEvacNow", []] remoteExec ["BIS_fnc_showNotification", units (group _target)];
         };
     };
 };
@@ -53,18 +55,19 @@ private _actionId = [
     toString {
         vgm_mission_onMission
         // is group leader
-        && leader _target == _target
+        && {leader _target == _target}
+        && {
+            private _helicopter = (group _target) getVariable ["vgm_missions_extraction_helicopter", objNull];
+            // extraction helicopter exists
+            !isNull _helicopter
+            // helicopter landed
+            && _helicopter getVariable ["vgm_missions_extractionLanded", false]
+            // forced extract action not run yet
+            && {!(_helicopter getVariable ["vgm_missions_extraction_evacNow", false])}
+        }
         // should not be possible to request extraction
-        && {!((group _target) getVariable ["vgm_missions_extraction_canRequest", true])}
-        // group leader is in vehicle
-        && {!isNull (objectParent _target)}
         // see: fn_missions_gameplay_extraction_startExtract.sqf
-        // group leader in extraction helo
-        && {(objectParent _target) == ((group _target) getVariable ["vgm_missions_extraction_helicopter", objNull])}
-        // forced extract action not run yet
-        && {!((objectParent _target) getVariable ["vgm_missions_extraction_evacNow", false])}
-        // forced timer extract action not run
-        && {((objectParent _target) getVariable ["vgm_missions_extraction_evacAt", -1]) isEqualTo -1}
+        && {!((group _target) getVariable ["vgm_missions_extraction_canRequest", true])}
     },
     "true",
     {},

--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacNow.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_evacNow.sqf
@@ -1,5 +1,5 @@
 /*
-    File: fn_missions_gameplay_extraction_addAction_evaNow.sqf
+    File: fn_missions_gameplay_extraction_addAction_evacNow.sqf
     Author: Savage Game Design
     Date: 2024-05-23
     Last Update: 2024-06-09

--- a/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_requestExtract.sqf
+++ b/game/functions/systems/missions_gameplay/client/extraction/fn_missions_gameplay_extraction_addAction_requestExtract.sqf
@@ -1,12 +1,12 @@
 /*
-    File: fn_missions_gameplay_extraction_addAction.sqf
+    File: fn_vgm_c_fnc_missions_gameplay_extraction_addAction_requestExtract.sqf
     Author: Savage Game Design
     Date: 2024-05-23
     Last Update: 2024-06-09
     Public: No
 
     Description:
-        Add action to request early extraction.
+        Add action to request extraction.
 
     Parameter(s):
         _player - Player to add the action to [OBJECT]
@@ -15,7 +15,7 @@
         Action ID [Number]
 
     Example(s):
-        [player] call vgm_c_fnc_missions_gameplay_extraction_addAction
+        [player] call vgm_c_fnc_missions_gameplay_extraction_addAction_requestExtract
  */
 
 params ["_player"];

--- a/game/functions/systems/missions_gameplay/client/fn_missions_gameplay_postInit.sqf
+++ b/game/functions/systems/missions_gameplay/client/fn_missions_gameplay_postInit.sqf
@@ -11,10 +11,14 @@
 
 if (!hasInterface) exitWith {};
 
-player call vgm_c_fnc_missions_gameplay_extraction_addAction;
+player call vgm_c_fnc_missions_gameplay_extraction_addAction_requestExtract;
+player call vgm_c_fnc_missions_gameplay_extraction_addAction_evacNow;
+player call vgm_c_fnc_missions_gameplay_extraction_addAction_evacAt;
 player addEventHandler ["Respawn", {
     params ["_player"];
-    _player call vgm_c_fnc_missions_gameplay_extraction_addAction;
+    _player call vgm_c_fnc_missions_gameplay_extraction_addAction_requestExtract;
+    _player call vgm_c_fnc_missions_gameplay_extraction_addAction_evacNow;
+    _player call vgm_c_fnc_missions_gameplay_extraction_addAction_evacAt;
 }];
 
 vgm_missions_gameplay_extraction_radioBackpacks = [

--- a/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
+++ b/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
@@ -61,6 +61,9 @@ if (_lzPosition isEqualTo []) exitWith {
 
 // spawn the helicopter, coming from the direction of the origin pos
 private _helicopter = [_class] call vgm_s_fnc_missions_gameplay_createCrewedHelicopter;
+// NOTE: For team leader dustOff hold action.
+// @dijksterhuis: if group leader dies then we'll need to pass this onto other group members, right?
+_playerGroup setVariable ["vgm_missions_extraction_helicopter", _helicopter, true];
 
 private _spawnPos = _lzPosition getPos [_distance, _lzPosition getDir _originPos];
 _spawnPos set [2, 50];
@@ -92,8 +95,11 @@ private _script = [_missionId, _mission, _helicopter, _helipad] spawn {
     private _playerGroup = _mission get "public" get "group";
     waitUntil {
         private _alivePlayers = units _playerGroup select {alive _x && !(_x call vgm_g_fnc_medical_isUnconscious)};
-        // all alive players are inside the heli, and there's at least one player alive.
-        _alivePlayers findIf {!(_x in _helicopter)} == -1 && _alivePlayers isNotEqualTo [];
+        private _everyoneBoarded = _alivePlayers findIf {!(_x in _helicopter)} == -1 && _alivePlayers isNotEqualTo [];
+        private _leaveNow = _helicopter getVariable ["vgm_missions_extraction_evacNow", false];
+        private _leaveAtTime = _helicopter getVariable ["vgm_missions_extraction_evacAt", -1];
+
+        _everyoneBoarded || _leaveNow || (_leaveAtTime isNotEqualTo -1 && serverTime > _leaveAtTime);
     };
 
     _helicopter setVariable ["vgm_missions_extractionBoarded", true];

--- a/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
+++ b/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
@@ -107,8 +107,7 @@ private _script = [_missionId, _mission, _helicopter, _helipad] spawn {
     ["vgm_missions_gameplay_extractionLiftOff", [_missionId, _helicopter], [2, _playerGroup]] call para_g_fnc_event_triggerTargets;
 
     private _landWp = group _helicopter addWaypoint [markerPos "vgm_mission_heli_despawn", 0];
-    // TODO - Put this back to 25
-    sleep 5;
+    sleep 25;
     private _endType = ["FAILURE", "SUCCESS"] select (units _playerGroup findIf {_x in _helicopter} > -1);
     [_missionId, _endType] call vgm_s_fnc_missions_endMission;
     waitUntil {crew _helicopter findIf {isPlayer _x} == -1};

--- a/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
+++ b/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
@@ -107,8 +107,10 @@ private _script = [_missionId, _mission, _helicopter, _helipad] spawn {
     ["vgm_missions_gameplay_extractionLiftOff", [_missionId, _helicopter], [2, _playerGroup]] call para_g_fnc_event_triggerTargets;
 
     private _landWp = group _helicopter addWaypoint [markerPos "vgm_mission_heli_despawn", 0];
-    sleep 25;
-    [_missionId] call vgm_s_fnc_missions_endMission;
+    // TODO - Put this back to 25
+    sleep 5;
+    private _endType = ["FAILURE", "SUCCESS"] select (units _playerGroup findIf {_x in _helicopter} > -1);
+    [_missionId, _endType] call vgm_s_fnc_missions_endMission;
     waitUntil {crew _helicopter findIf {isPlayer _x} == -1};
     sleep 25;
     {_helicopter deleteVehicleCrew _x} forEach units _helicopter;

--- a/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
+++ b/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
@@ -2,7 +2,7 @@
     File: fn_missions_gameplay_extraction_callExtract.sqf
     Author: Savage Game Design
     Date: 2023-11-24
-    Last Update: 2025-03-23
+    Last Update: 2025-08-24
     Public: No
 
     Description:
@@ -61,8 +61,6 @@ if (_lzPosition isEqualTo []) exitWith {
 
 // spawn the helicopter, coming from the direction of the origin pos
 private _helicopter = [_class] call vgm_s_fnc_missions_gameplay_createCrewedHelicopter;
-// NOTE: For team leader dustOff hold action.
-// @dijksterhuis: if group leader dies then we'll need to pass this onto other group members, right?
 _playerGroup setVariable ["vgm_missions_extraction_helicopter", _helicopter, true];
 
 private _spawnPos = _lzPosition getPos [_distance, _lzPosition getDir _originPos];

--- a/game/mission/stringtable.xml
+++ b/game/mission/stringtable.xml
@@ -1311,6 +1311,12 @@
         <Key ID="STR_VGM_MISSIONS_EXTRACTION_REQUEST_ACTION">
             <Original>Request extraction</Original>
         </Key>
+        <Key ID="STR_VGM_MISSIONS_EXTRACTION_EVACNOW_ACTION">
+            <Original>Extract Now!</Original>
+        </Key>
+        <Key ID="STR_VGM_MISSIONS_EXTRACTION_EVACTIMER_ACTION">
+            <Original>Start Extract Timer</Original>
+        </Key>
         <Key ID="STR_VGM_MISSIONS_EXTRACTION_REQUEST_NO_RADIO">
             <Original>No radio or RTO nearby to call for extraction.</Original>
         </Key>
@@ -1322,6 +1328,15 @@
         </Key>
         <Key ID="STR_VGM_MISSIONS_EXTRACTION_TASK_BOARD_TITLE">
             <English>Board the helicopter</English>
+        </Key>
+        <Key ID="STR_VGM_MISSIONS_EXTRACTION_NOTIFICATION_TITLE">
+            <English>Extraction</English>
+        </Key>
+        <Key ID="STR_VGM_MISSIONS_EXTRACTION_NOTIFICATION_EVACNOW_DESCRIPTION">
+            <English>Extract helicopter leaving!</English>
+        </Key>
+        <Key ID="STR_VGM_MISSIONS_EXTRACTION_NOTIFICATION_EVACAT_DESCRIPTION">
+            <English>Extract helicopter leaving in 30 seconds!</English>
         </Key>
     </Package>
     <Package name="Missions Scouting">

--- a/game/mission/stringtable.xml
+++ b/game/mission/stringtable.xml
@@ -1315,10 +1315,19 @@
             <Original>Extract Now!</Original>
         </Key>
         <Key ID="STR_VGM_MISSIONS_EXTRACTION_EVACTIMER_ACTION">
-            <Original>Start Extract Timer</Original>
+            <Original>Extract in 30 seconds!</Original>
         </Key>
         <Key ID="STR_VGM_MISSIONS_EXTRACTION_REQUEST_NO_RADIO">
             <Original>No radio or RTO nearby to call for extraction.</Original>
+        </Key>
+        <Key ID="STR_VGM_MISSIONS_EXTRACTION_EXTRACT_NO_RADIO">
+            <Original>No radio or RTO nearby, board the helicopter to force extraction.</Original>
+        </Key>
+        <Key ID="STR_VGM_MISSIONS_EXTRACTION_CONFIRM_TIMED_EXTRACTION">
+            <Original>Start extraction countdown? Team will be notified and have 30 seconds to board the helicopter.</Original>
+        </Key>
+        <Key ID="STR_VGM_MISSIONS_EXTRACTION_CONFIRM_IMMEDIATE_EXTRACTION">
+            <Original>Extract immediately? Remaining team members will be abandoned.</Original>
         </Key>
         <Key ID="STR_VGM_MISSIONS_EXTRACTION_TASK_MAIN_TITLE">
             <English>Extract from AO</English>


### PR DESCRIPTION
Deals with: Allow team leader to start a timer for the extraction helicopter to leave. (Can be an addAction) Anti-griefing measure

- Timed evac (30 seconds) uses `serverTime` to wait.
- Immediate goes immediately

Review items
- Will conflict with #305 -- see note there.
- Variable set and sync'd client-server on helicopter object. Would group be better? Or a different mechanism (non-syncing Variables). 
- Names of things
- Text, stringtable entries etc