### PR TITLE
Extraction: Refactor to workaround free-falling players bug.

### DIFF
--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -296,6 +296,14 @@ class vgm_g
         };
     };
 
+    class missions_gameplay_extraction
+    {
+        VGM_GLOBAL_PATH(\systems\missions_gameplay\global\extraction);
+
+        class missions_gameplay_extraction_fadeInOrOut {};
+    };
+
+
     class missions_zones
     {
         VGM_GLOBAL_PATH(\systems\missions_zones\global);

--- a/game/functions/functions_server.hpp
+++ b/game/functions/functions_server.hpp
@@ -179,6 +179,7 @@ class vgm_s
 
         class missions_gameplay_extraction_scriptedLand {};
         class missions_gameplay_extraction_startExtract {};
+        class missions_gameplay_extraction_doExtract {};
     };
 
     class missions_gameplay_scouting

--- a/game/functions/systems/missions/client/internal/fn_missions_endMission.sqf
+++ b/game/functions/systems/missions/client/internal/fn_missions_endMission.sqf
@@ -32,16 +32,17 @@ vgm_mission_onMission = false;
 private _currentMission = [] call vgm_c_fnc_missions_getCurrentMission;
 ["vgm_mission_end_local", _currentMission] call para_g_fnc_event_triggerLocal;
 
-[] spawn {
-    waitUntil {vehicle player == player};
+// TODO: Should no longer need to spawn and check here?
+// [] spawn {
+//     waitUntil {vehicle player == player};
 
-    player setVelocity [0,0,0];
-    ([] call vgm_g_fnc_missions_getHubSpawnPos) params ["_newPos", "_newDir"];
-    player setDir _newDir;
-    player setVehiclePosition [_newPos, [], 0, "NONE"];
-    player call vgm_c_fnc_medical_fullHeal;
-};
-moveOut player;
+// };
+// moveOut player;
+player setVelocity [0,0,0];
+([] call vgm_g_fnc_missions_getHubSpawnPos) params ["_newPos", "_newDir"];
+player setDir _newDir;
+player setVehiclePosition [_newPos, [], 0, "NONE"];
+player call vgm_c_fnc_medical_fullHeal;
 
 terminate (missionNamespace getVariable ["vgm_missions_zoomOnMapScript", scriptNull]);
 [] call vgm_c_fnc_missions_coverMap;

--- a/game/functions/systems/missions/client/internal/fn_missions_endMission.sqf
+++ b/game/functions/systems/missions/client/internal/fn_missions_endMission.sqf
@@ -32,12 +32,6 @@ vgm_mission_onMission = false;
 private _currentMission = [] call vgm_c_fnc_missions_getCurrentMission;
 ["vgm_mission_end_local", _currentMission] call para_g_fnc_event_triggerLocal;
 
-// TODO: Should no longer need to spawn and check here?
-// [] spawn {
-//     waitUntil {vehicle player == player};
-
-// };
-// moveOut player;
 player setVelocity [0,0,0];
 ([] call vgm_g_fnc_missions_getHubSpawnPos) params ["_newPos", "_newDir"];
 player setDir _newDir;

--- a/game/functions/systems/missions_gameplay/global/extraction/fn_missions_gameplay_extraction_fadeInOrOut.sqf
+++ b/game/functions/systems/missions_gameplay/global/extraction/fn_missions_gameplay_extraction_fadeInOrOut.sqf
@@ -1,0 +1,57 @@
+/*
+    File: fn_missions_gameplay_extraction_fadeInOrOut.sqf
+    Author: Savage Game Design
+    Date: 2025-01-03
+    Last Update: 2025-01-09
+    Public: No
+
+    Description:
+        Scripted helicopter land.
+
+    Parameter(s):
+        _helicopter - Helicopter that will be guided to the helipad [OBJECT]
+
+    Returns:
+        Nothing
+
+    Example(s):
+        private _landWp = _group addWaypoint [_wpPos, 0];
+        _helicopter setVariable ["vgm_mission_extraction_helipad", _helipad];
+        _landWp setWaypointStatements ["true", toString {
+            if (!isServer) exitWith {};
+            [vehicle this] call vgm_s_fnc_missions_gameplay_extraction_scriptedLand;
+        }];
+ */
+
+
+params [
+    ["_fadeInOrOut", "OUT"],
+    ["_seconds", 10],
+    ["_players", []]
+];
+
+if (_seconds < 0) exitWith {
+    nil // return
+};
+
+if (count _players isEqualTo 0) exitWith {
+    nil // return
+};
+
+switch (_fadeInOrOut) do {
+    case "IN": {
+        [1, "BLACK", _seconds, 1] remoteExec ["BIS_fnc_fadeEffect", _players];
+        [_seconds, 0] remoteExec ["fadeSound", _players];
+        // [1, "BLACK", _seconds, 1] spawn BIS_fnc_fadeEffect;
+        // _seconds fadeSound 0;
+    };
+    case "OUT": {
+        [0, "BLACK", _seconds, 1] remoteExec ["BIS_fnc_fadeEffect", _players];
+        [_seconds, 1] remoteExec ["fadeSound", _players];
+        // [0, "BLACK", _seconds, 1] spawn BIS_fnc_fadeEffect;
+        // _seconds fadeSound 1;
+    };
+    default {};
+};
+
+nil // return

--- a/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_doExtract.sqf
+++ b/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_doExtract.sqf
@@ -1,0 +1,180 @@
+/*
+    File: fn_missions_gameplay_extraction_doExtract.sqf
+    Author: Savage Game Design
+    Date: 2025-08-16
+    Last Update: 2025-08-16
+    Public: No
+
+    Description:
+        Do the helicopter extraction (liftoff, fly away, clean up etc) for the given mission extraction.
+
+        ** MUST BE RUN IN SCHEDULED ENVIRONEMNT **
+
+    Parameter(s):
+        _missionId - ID of the mission [NUMBER]
+        _playerGroup - [GROUP]
+        _helicopter - [OBJECT]
+        _helidpadLZ - [OBJECT]
+
+    Returns:
+        Nothing (scheduled)
+
+    Example(s):
+        ```
+        private _helicopter = ["vn_b_air_uh1d_02_07"] call vgm_s_fnc_missions_gameplay_createCrewedHelicopter;
+
+        private _helipad = createVehicle ["Land_HelipadEmpty_F", [0,0,0], [], 0, "NONE"];
+        _helipad setPosATL (getPosATL (allPlayers select 0));
+
+        [1, group (allPlayers select 0), _helicopter, _helipad] spawn vgm_s_fnc_missions_gameplay_extraction_doExtract;
+        ```
+*/
+
+#define FADE_DURATION 5
+
+params ["_missionId", "_playerGroup", "_helicopter", "_helipadLz"];
+
+if (!canSuspend) exitWith {
+    format ["Attempted to execute scheduled code in unscheduled environment: script=%1", _scriptName] call vgm_g_fnc_logError;
+    nil // return
+};
+
+//////////////////////////////////////////////////////////////////
+// 0. WAIT FOR PLAYERS TO BOARD / FORCE EXTRACT
+//////////////////////////////////////////////////////////////////
+
+waitUntil {
+    sleep 1;
+    private _alivePlayers = units _playerGroup select {alive _x && !(_x call vgm_g_fnc_medical_isUnconscious)};
+    private _everyoneBoarded = _alivePlayers findIf {!(_x in _helicopter)} == -1 && _alivePlayers isNotEqualTo [];
+    private _leaveNow = _helicopter getVariable ["vgm_missions_extraction_evacNow", false];
+    private _leaveAtTime = _helicopter getVariable ["vgm_missions_extraction_evacAt", -1];
+
+    // _everyoneBoarded ||
+    _leaveNow || (_leaveAtTime isNotEqualTo -1 && serverTime > _leaveAtTime);
+};
+
+private _group = group _helicopter;
+
+//////////////////////////////////////////////////////////////////
+// 1. EXFIL TOWARDS BASE
+//////////////////////////////////////////////////////////////////
+
+_helicopter setVariable ["vgm_missions_extractionBoarded", true];
+_helicopter flyInHeight [100, true];
+_helicopter setCaptive false;
+
+deleteVehicle _helipadLz;
+_helicopter setVariable ["vgm_mission_extraction_helipad", nil];
+
+["vgm_missions_gameplay_extractionLiftOff", [_missionId, _helicopter], [2, _playerGroup]] call para_g_fnc_event_triggerTargets;
+_group addWaypoint [markerPos "vgm_mission_heli_despawn", 0];
+
+// post exfil travel time for imerrrshhhion
+sleep 25;
+private _playersInHelo = (units _playerGroup) select {isPlayer _x} select {_helicopter isEqualTo objectParent _x};
+private _playersNotInHelo = (units _playerGroup) select {isPlayer _x} select {IsNull objectParent _x};
+
+["OUT", FADE_DURATION, _playersInHelo] call vgm_g_fnc_missions_gameplay_extraction_fadeInOrOut;
+
+// wait for fade out to complete before teleporting helo etc.
+sleep FADE_DURATION + 5;
+
+//////////////////////////////////////////////////////////////////
+// 2. TELEPORT HELO
+//////////////////////////////////////////////////////////////////
+
+// TODO: multiple missions could end at the same time
+// TODO: Is 3 enough? Can have like 5 missions running concurrently, right?
+// [NORTHERN INGRESS + HELIPAD, WESTERN INGRESS + HELIPAD, SOUTHERN INGRESS + HELIPAD]
+// TODO: EDITOR MARKERS
+private _heloTeleportPositions = [
+    [18950, 7650, 50],  // NORTH
+    [18160, 7495, 50],  // MID 1
+    [18180, 6260, 50],  // MID 2
+    [20010, 4755, 50]   // SOUTH
+];
+private _baseLandingPositions = [
+    [20000, 6582, 0],  // NORTH
+    [20005, 6566, 0],  // MID 1
+    [20008, 6549, 0],  // MID 2
+    [20015, 6535, 0]   // SOUTH
+];
+
+// TODO: Is there a variable for "Maximum number of missons"?
+private _startIngressPos = _heloTeleportPositions select (_missionId mod 4);
+private _baseLandingPos = _baseLandingPositions select (_missionId mod 4);
+
+// delete all existing waypoints and teleport to new position
+// TODO: Do we need to delete the waypoints?
+for "_i" from (count waypoints _group - 1) to 0 step -1 do {deleteWaypoint [_group, _i];};
+_helicopter setDir (_startIngressPos getDir _baseLandingPos);
+_helicopter setPosATL _startIngressPos;
+
+//////////////////////////////////////////////////////////////////
+// 3. INGRESS TO BASE
+//////////////////////////////////////////////////////////////////
+
+private _helipadBase = createVehicle [["Land_HelipadEmpty_F", "Land_HelipadCircle_F"] select is3DENPreview, [0,0,0], [], 0, "NONE"];
+_helipadBase setPosATL _baseLandingPos;
+_helicopter setVariable ["vgm_mission_extraction_helipad", _helipadBase];
+
+// TODO: This is bugged for some reason?!
+private _wpPos = _baseLandingPos getPos [100, _startIngressPos getDir _baseLandingPos];
+private _landWp = _group addWaypoint [_wpPos, 0];
+
+_landWp setWaypointStatements ["true", toString {
+    if (!isServer) exitWith {};
+    [vehicle this] call vgm_s_fnc_missions_gameplay_extraction_scriptedLand;
+}];
+
+// give helo a few seconds to start flying properly to avoid any jank
+sleep FADE_DURATION;
+// bird should be flying by this point
+["IN", FADE_DURATION, _playersInHelo] call vgm_g_fnc_missions_gameplay_extraction_fadeInOrOut;
+// fade out abandoned players not in helo now
+// we'll fade them back in during mission end
+["OUT", FADE_DURATION, _playersNotInHelo] call vgm_g_fnc_missions_gameplay_extraction_fadeInOrOut;
+sleep FADE_DURATION;
+
+// force disable simulation on abandoned players until we bring them back
+_playersNotInHelo apply {
+    _x enableSimulationGlobal true;
+    _x setPosATL [0, 0, 0];
+};
+
+// dismount players once velocity is low enough (on ground)
+// OR players have ejected from the helo, continue
+waitUntil {sleep 1; (_helicopter distance _helipadBase) < 1 || crew _helicopter findIf {isPlayer _x} == -1};
+units _playerGroup select {vehicle _x isNotEqualTo _x} apply {moveOut _x};
+
+//////////////////////////////////////////////////////////////////
+// 4. PLAYER DEBRIEF & HELO / HELIPAD DESPAWN
+//////////////////////////////////////////////////////////////////
+
+// Once players are no longer in helo:
+// * debrief players via `missionEnd` screen
+// * make chopper fly away to despawn out of sight
+//
+// NOTE: Players could decide to ceremoniously yeet/eject themselves because reasons.
+// This should cover that case too -- missionEnd will run and helo heads to pleiku for despawn.
+waitUntil {sleep 1; crew _helicopter findIf {isPlayer _x} == -1};
+_playersNotInHelo apply {_x enableSimulationGlobal true};
+[_missionId] call vgm_s_fnc_missions_endMission;
+// bring back any abandoned players
+["IN", 0, _playersNotInHelo] call vgm_g_fnc_missions_gameplay_extraction_fadeInOrOut;
+
+_helicopter flyInHeight [100, true];
+_helicopter setCaptive true;
+
+for "_i" from (count waypoints _group - 1) to 0 step -1 do {deleteWaypoint [_group, _i];};
+_group addWaypoint [markerPos "vgm_mission_heli_despawn", 0];
+
+// time until safely out of view / earshot
+sleep 45;
+
+{_helicopter deleteVehicleCrew _x} forEach units _helicopter;
+deleteVehicle _helicopter;
+deleteVehicle _helipadBase;
+
+nil;

--- a/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_doExtract.sqf
+++ b/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_doExtract.sqf
@@ -35,7 +35,7 @@
 params ["_missionId", "_playerGroup", "_helicopter", "_helipadLz"];
 
 if (!canSuspend) exitWith {
-    format ["Attempted to execute scheduled code in unscheduled environment: script=%1", _scriptName] call vgm_g_fnc_logError;
+    "Attempted to execute scheduled code in unscheduled environment" call vgm_g_fnc_logError;
     nil // return
 };
 
@@ -50,8 +50,7 @@ waitUntil {
     private _leaveNow = _helicopter getVariable ["vgm_missions_extraction_evacNow", false];
     private _leaveAtTime = _helicopter getVariable ["vgm_missions_extraction_evacAt", -1];
 
-    // _everyoneBoarded ||
-    _leaveNow || (_leaveAtTime isNotEqualTo -1 && serverTime > _leaveAtTime);
+    _everyoneBoarded || _leaveNow || (_leaveAtTime isNotEqualTo -1 && serverTime > _leaveAtTime);
 };
 
 private _group = group _helicopter;
@@ -70,30 +69,28 @@ _helicopter setVariable ["vgm_mission_extraction_helipad", nil];
 ["vgm_missions_gameplay_extractionLiftOff", [_missionId, _helicopter], [2, _playerGroup]] call para_g_fnc_event_triggerTargets;
 _group addWaypoint [markerPos "vgm_mission_heli_despawn", 0];
 
-// post exfil travel time for imerrrshhhion
-sleep 25;
+sleep 25;  // post exfil travel time
+
 private _playersInHelo = (units _playerGroup) select {isPlayer _x} select {_helicopter isEqualTo objectParent _x};
 private _playersNotInHelo = (units _playerGroup) select {isPlayer _x} select {IsNull objectParent _x};
 
 ["OUT", FADE_DURATION, _playersInHelo] call vgm_g_fnc_missions_gameplay_extraction_fadeInOrOut;
 
-// wait for fade out to complete before teleporting helo etc.
-sleep FADE_DURATION + 5;
+sleep FADE_DURATION + 5;  // guarantee fade out is completed before teleporting helo
 
 //////////////////////////////////////////////////////////////////
 // 2. TELEPORT HELO
 //////////////////////////////////////////////////////////////////
 
-// TODO: multiple missions could end at the same time
-// TODO: Is 3 enough? Can have like 5 missions running concurrently, right?
-// [NORTHERN INGRESS + HELIPAD, WESTERN INGRESS + HELIPAD, SOUTHERN INGRESS + HELIPAD]
-// TODO: EDITOR MARKERS
+// TODO: USE EDITOR MARKERS
 private _heloTeleportPositions = [
     [18950, 7650, 50],  // NORTH
     [18160, 7495, 50],  // MID 1
     [18180, 6260, 50],  // MID 2
     [20010, 4755, 50]   // SOUTH
 ];
+
+// TODO: USE EDITOR MARKERS
 private _baseLandingPositions = [
     [20000, 6582, 0],  // NORTH
     [20005, 6566, 0],  // MID 1
@@ -101,7 +98,7 @@ private _baseLandingPositions = [
     [20015, 6535, 0]   // SOUTH
 ];
 
-// TODO: Is there a variable for "Maximum number of missons"?
+// TODO: Is there a global variable for "Maximum number of missons"?
 private _startIngressPos = _heloTeleportPositions select (_missionId mod 4);
 private _baseLandingPos = _baseLandingPositions select (_missionId mod 4);
 
@@ -129,22 +126,21 @@ _landWp setWaypointStatements ["true", toString {
 }];
 
 // give helo a few seconds to start flying properly to avoid any jank
+// once it is proceeding, fade in for players in helo and fade out abandoned players in the mission area.
+// abandoned players will be faded back in during missionEnd,
+// disable sim and stick abandoned players in debug to make sure they don't take damage
+
 sleep FADE_DURATION;
-// bird should be flying by this point
 ["IN", FADE_DURATION, _playersInHelo] call vgm_g_fnc_missions_gameplay_extraction_fadeInOrOut;
-// fade out abandoned players not in helo now
-// we'll fade them back in during mission end
 ["OUT", FADE_DURATION, _playersNotInHelo] call vgm_g_fnc_missions_gameplay_extraction_fadeInOrOut;
 sleep FADE_DURATION;
-
-// force disable simulation on abandoned players until we bring them back
 _playersNotInHelo apply {
     _x enableSimulationGlobal true;
     _x setPosATL [0, 0, 0];
 };
 
-// dismount players once velocity is low enough (on ground)
-// OR players have ejected from the helo, continue
+// dismount players once helo is on the invisible helipad or players have ejected from the helo.
+// (all players ejecting here will cause a hardlocked and unrecoverable mission outcome!)
 waitUntil {sleep 1; (_helicopter distance _helipadBase) < 1 || crew _helicopter findIf {isPlayer _x} == -1};
 units _playerGroup select {vehicle _x isNotEqualTo _x} apply {moveOut _x};
 
@@ -152,12 +148,9 @@ units _playerGroup select {vehicle _x isNotEqualTo _x} apply {moveOut _x};
 // 4. PLAYER DEBRIEF & HELO / HELIPAD DESPAWN
 //////////////////////////////////////////////////////////////////
 
-// Once players are no longer in helo:
-// * debrief players via `missionEnd` screen
-// * make chopper fly away to despawn out of sight
-//
-// NOTE: Players could decide to ceremoniously yeet/eject themselves because reasons.
-// This should cover that case too -- missionEnd will run and helo heads to pleiku for despawn.
+// Once players are no longer in helo debrief players via `missionEnd` screen and 
+// make chopper fly away to despawn out of sight
+
 waitUntil {sleep 1; crew _helicopter findIf {isPlayer _x} == -1};
 _playersNotInHelo apply {_x enableSimulationGlobal true};
 [_missionId] call vgm_s_fnc_missions_endMission;
@@ -170,11 +163,9 @@ _helicopter setCaptive true;
 for "_i" from (count waypoints _group - 1) to 0 step -1 do {deleteWaypoint [_group, _i];};
 _group addWaypoint [markerPos "vgm_mission_heli_despawn", 0];
 
-// time until safely out of view / earshot
-sleep 45;
+sleep 45;  // time until safely out of view / earshot
 
 {_helicopter deleteVehicleCrew _x} forEach units _helicopter;
 deleteVehicle _helicopter;
 deleteVehicle _helipadBase;
 
-nil;

--- a/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
+++ b/game/functions/systems/missions_gameplay/server/extraction/fn_missions_gameplay_extraction_startExtract.sqf
@@ -87,30 +87,7 @@ _landWp setWaypointStatements ["true", toString {
     [vehicle this] call vgm_s_fnc_missions_gameplay_extraction_scriptedLand;
 }];
 
-private _script = [_missionId, _mission, _helicopter, _helipad] spawn {
-    params ["_missionId", "_mission", "_helicopter", "_helipad"];
-    private _playerGroup = _mission get "public" get "group";
-    waitUntil {
-        private _alivePlayers = units _playerGroup select {alive _x && !(_x call vgm_g_fnc_medical_isUnconscious)};
-        // all alive players are inside the heli, and there's at least one player alive.
-        _alivePlayers findIf {!(_x in _helicopter)} == -1 && _alivePlayers isNotEqualTo [];
-    };
-
-    _helicopter setVariable ["vgm_missions_extractionBoarded", true];
-    _helicopter flyInHeight [100, true];
-    _helicopter setCaptive false;
-
-    ["vgm_missions_gameplay_extractionLiftOff", [_missionId, _helicopter], [2, _playerGroup]] call para_g_fnc_event_triggerTargets;
-
-    private _landWp = group _helicopter addWaypoint [markerPos "vgm_mission_heli_despawn", 0];
-    sleep 25;
-    [_missionId] call vgm_s_fnc_missions_endMission;
-    waitUntil {crew _helicopter findIf {isPlayer _x} == -1};
-    sleep 25;
-    {_helicopter deleteVehicleCrew _x} forEach units _helicopter;
-    deleteVehicle _helicopter;
-    deleteVehicle _helipad;
-};
+private _script = [_missionId, _playerGroup, _helicopter, _helipad] spawn vgm_s_fnc_missions_gameplay_extraction_doExtract;
 
 _group setVariable ["vgm_missions_extractionScript", _script];
 


### PR DESCRIPTION
conflict with #304 -- `startExtract` -- the `private _script` section

TODO:
- [ ] possibly simpler solution with [setUnitFreefallHeight](https://community.bistudio.com/wiki/setUnitFreefallHeight) (suggested by @veteran29)

Notes for Review
- [`fn_missions_gameplay_extraction_doExtract.sqf`](https://github.com/Savage-Game-Design/Across-the-Fence/pull/305/files/8872f86b610ffe3be41149eb903574977d5ad3dc#diff-955ca6e3adbe15edebd96c917635b1b2706c6ba218e47c244251100a1acd4424) is the important file
- possibility to simplify by moving out players from static helo on ground at pleiku https://github.com/Savage-Game-Design/Across-the-Fence/pull/305#discussion_r2295021169
- as mentioned, aware a fade In/Out effect script exists, mine was just a quick mock up to get something working without having to touch other code
- also handles immersion issues/edge cases introduced in #304 