### PR TITLE
Extraction: Fix freefalling player mission end (simple 1x command version)

### DIFF
--- a/game/functions/systems/missions/client/internal/fn_missions_endMission.sqf
+++ b/game/functions/systems/missions/client/internal/fn_missions_endMission.sqf
@@ -32,14 +32,16 @@ vgm_mission_onMission = false;
 private _currentMission = [] call vgm_c_fnc_missions_getCurrentMission;
 ["vgm_mission_end_local", _currentMission] call para_g_fnc_event_triggerLocal;
 
+player setUnitFreefallHeight 5000;
 [] spawn {
     waitUntil {vehicle player == player};
-
     player setVelocity [0,0,0];
+
     ([] call vgm_g_fnc_missions_getHubSpawnPos) params ["_newPos", "_newDir"];
     player setDir _newDir;
     player setVehiclePosition [_newPos, [], 0, "NONE"];
     player call vgm_c_fnc_medical_fullHeal;
+    player setUnitFreefallHeight -1;
 };
 moveOut player;
 


### PR DESCRIPTION
uses `setUnitFreefallHeight` to trick the engine while player is moving out of vehicle in flight.

kudos to @veteran29 

tested twice locally and seems to work (only for helo extract, not respawn mission end / exited helo during extract mission end)

- needs testing for any "timing" issues on dedicated server environment
- might be prudent to set `setUnitFreefallHeight` on player respawn? is not reset on player death by default