### PR TITLE
Missions: Highlight target zone on mission join.

### DIFF
--- a/game/functions/functions_client.hpp
+++ b/game/functions/functions_client.hpp
@@ -536,6 +536,7 @@ class vgm_c
         VGM_CLIENT_PATH(\systems\missions\client);
 
         class missions_coverMap {};
+        class missions_highlightOrHideZone {};
         class missions_getCurrentMission {};
         class missions_getMissions {};
         class missions_makeMissionGiver {};

--- a/game/functions/systems/missions/client/fn_missions_highlightOrHideZone.sqf
+++ b/game/functions/systems/missions/client/fn_missions_highlightOrHideZone.sqf
@@ -1,0 +1,39 @@
+/*
+    File: fn_missions_highlightOrHideZone.sqf
+    Author: Savage Game Design
+    Date: 2025-09-07
+    Last Update: 2025-09-07
+    Public: No
+
+    Description:
+        If mission is assigned to the player: highlight the zone to allow players to plan.
+        Else, removes any existing target box and resets map.
+
+    Parameter(s):
+        None
+
+    Returns:
+        Nothing
+
+    Example(s):
+        [] remoteExecCall ["vgm_c_fnc_missions_highlightOrHideZone", _player];
+*/
+
+private _currentMission = [] call vgm_c_fnc_missions_getCurrentMission;
+
+// will hide zone target boxes if no mission assigned
+[] call vgm_c_fnc_missions_coverMap;
+
+if (isNil "_currentMission") exitWith {};
+
+openMap [true, false];
+// zoom map on the mission area if a mission is assigned
+vgm_missions_zoomOnMapScript = (_currentMission get "targetZone") spawn {
+    [_this] call vgm_g_fnc_loc_getTargetBoxBounds params ["_pos", "_size"];
+    waitUntil {visibleMap}; // can't animate hidden map
+    [
+        _size vectorMultiply 2.5,
+        _pos,
+        1
+    ] call BIS_fnc_zoomOnArea;
+};

--- a/game/functions/systems/missions/client/fn_missions_highlightOrHideZone.sqf
+++ b/game/functions/systems/missions/client/fn_missions_highlightOrHideZone.sqf
@@ -26,7 +26,6 @@ private _currentMission = [] call vgm_c_fnc_missions_getCurrentMission;
 
 if (isNil "_currentMission") exitWith {};
 
-openMap [true, false];
 // zoom map on the mission area if a mission is assigned
 vgm_missions_zoomOnMapScript = (_currentMission get "targetZone") spawn {
     [_this] call vgm_g_fnc_loc_getTargetBoxBounds params ["_pos", "_size"];

--- a/game/functions/systems/missions/client/internal/fn_missions_finishDeploy.sqf
+++ b/game/functions/systems/missions/client/internal/fn_missions_finishDeploy.sqf
@@ -34,18 +34,6 @@ _this spawn {
 
     ["vgm_mission_deploy_local", _currentMission] call para_g_fnc_event_triggerLocal;
 
-    // zoom map on the mission area
-    [] call vgm_c_fnc_missions_coverMap;
-    vgm_missions_zoomOnMapScript = (_currentMission get "targetZone") spawn {
-        [_this] call vgm_g_fnc_loc_getTargetBoxBounds params ["_pos", "_size"];
-        waitUntil {visibleMap}; // can't animate hidden map
-        [
-            _size vectorMultiply 2.5,
-            _pos,
-            0
-        ] call BIS_fnc_zoomOnArea;
-    };
-
     // - Unfades the screen
     sleep 1;
     [1] spawn BIS_fnc_fadeEffect;

--- a/game/functions/systems/missions/server/internal/fn_missions_attachPlayerToMission.sqf
+++ b/game/functions/systems/missions/server/internal/fn_missions_attachPlayerToMission.sqf
@@ -60,6 +60,9 @@ if (isNull (_missionPublic get "group")) then {
 private _playerUnit = _playerId call vgm_s_fnc_player_fromId;
 [[_playerUnit], _missionPublic get "group"] remoteExec ["joinSilent", _playerUnit];
 
+// highlights target box and zooms player in with visible map
+[] remoteExecCall ["vgm_c_fnc_missions_highlightOrHideZone", _playerUnit];
+
 [
     "vgm_mission_attached",
     [_playerId, _missionPublic get "id"]

--- a/game/functions/systems/missions/server/internal/fn_missions_removePlayerFromMission.sqf
+++ b/game/functions/systems/missions/server/internal/fn_missions_removePlayerFromMission.sqf
@@ -40,6 +40,9 @@ private _playerUnit = _playerId call vgm_s_fnc_player_fromId;
 // joinSilent seems to sometimes mysteriously fail. RemoteExec'ing is an attempt to solve that.
 [[_playerUnit], vgm_core_lobbyGroup] remoteExec ["joinSilent", _playerUnit];
 
+// removes target box on zone
+[] remoteExecCall ["vgm_c_fnc_missions_highlightOrHideZone", _playerUnit];
+
 [
     "vgm_mission_playerRemoved",
     [_playerId, _missionPublic get "id"]


### PR DESCRIPTION
Target area box now applied when mission joined. Map is also opened and zooms in on target box on join.

hides the target area box on leaving a mission.