### PR TITLE
'HandleDisconnect' bugfix: player characters no longer turn into AI on disconnect

### DIFF
--- a/game/functions/systems/carry/server/fn_carry_preInit.sqf
+++ b/game/functions/systems/carry/server/fn_carry_preInit.sqf
@@ -18,6 +18,10 @@ addMissionEventHandler ["HandleDisconnect", {
 
     // drop carried unit when carrier disconnects
     [objNull, _target] call vgm_s_fnc_carry_detachRequest;
+
+    // if this EH code returns true... player... becomes AI
+    // https://community.bistudio.com/wiki/Arma_3:_Mission_Event_Handlers#HandleDisconnect
+    false
 }];
 
 addMissionEventHandler ["EntityKilled", {

--- a/game/functions/systems/persistence/server/fn_persistence_preInit.sqf
+++ b/game/functions/systems/persistence/server/fn_persistence_preInit.sqf
@@ -33,5 +33,8 @@ vgm_persistence_dirtySchemas = createHashMap;
 
     addMissionEventHandler ["HandleDisconnect", {
         [] call vgm_s_fnc_persistence_dbCommit;
+        // if this EH code returns true... player... becomes AI
+        // https://community.bistudio.com/wiki/Arma_3:_Mission_Event_Handlers#HandleDisconnect
+        false
     }];
 };

--- a/game/functions/systems/shared_hub/server/fn_sharedHub_preInit.sqf
+++ b/game/functions/systems/shared_hub/server/fn_sharedHub_preInit.sqf
@@ -15,4 +15,8 @@ addMissionEventHandler ["HandleDisconnect", {
     if (_unit inArea "vgm_shared_hub") then {
         deleteVehicle _unit;
     };
+
+    // if this EH code returns true... player... becomes AI
+    // https://community.bistudio.com/wiki/Arma_3:_Mission_Event_Handlers#HandleDisconnect
+    false
 }];


### PR DESCRIPTION
changed all `HandleDisconnect` mission event handlers to return false, and included a note to stop anyone from making the same mistake again in the future.