### PR TITLE
Equipment: Scout: Fix M3A1 suppressor typo.

### DIFF
--- a/game/configs/mission/cfg_equipment_generated.hpp
+++ b/game/configs/mission/cfg_equipment_generated.hpp
@@ -1046,7 +1046,7 @@ class scout_03 {
     };
 
     items[] = {
-        "vn_s_M3a1"
+        "vn_s_m3a1"
     };
 };
 


### PR DESCRIPTION
#343 will fix, but this makes everything lowercase and is ultimately the pedantic solution.