### PR TITLE
Skills: Add 'modals' for skills respec interactions

### DIFF
--- a/game/functions/systems/skills/client/network/fn_skills_receiveSkillRespec.sqf
+++ b/game/functions/systems/skills/client/network/fn_skills_receiveSkillRespec.sqf
@@ -29,6 +29,11 @@ uiNamespace setVariable ["BIS_fnc_guiMessage_status", _result];
 
 player setUnitLoadout EMPTY_LOADOUT;
 
-hint "Skill respec done";
-
 ["vgm_skills_respecLocal"] call para_g_fnc_event_triggerLocal;
+
+[
+    "Skills reset. Re-assign your refunded skill points in the skills menu.",
+    "",
+    true,
+    false
+] spawn BIS_fnc_guiMessage;

--- a/game/functions/systems/skills/client/network/fn_skills_requestSkillRespec.sqf
+++ b/game/functions/systems/skills/client/network/fn_skills_requestSkillRespec.sqf
@@ -18,8 +18,17 @@
         [] call vgm_c_fnc_skills_requestSkillRespec
  */
 
-params [["_displayParent", nil]];
+[player] spawn {
+    params ["_player"];
 
-["Waiting for server...", "Please wait", false, false, _displayParent] spawn BIS_fnc_guiMessage;
+    private _result = [
+        "Are you sure you want to reset all your skills? (Spent skill points will be refunded).",
+        "",
+        true,
+        true
+    ] call BIS_fnc_guiMessage;
 
-[player] remoteExecCall ["vgm_s_fnc_skills_handle_skillRespecRequest", 2];
+    if (_result) then {
+        [_player] remoteExecCall ["vgm_s_fnc_skills_handle_skillRespecRequest", 2];
+    };
+};


### PR DESCRIPTION
fixes the `BIS_fnc_guiMessage` script error -- `fn_skills_requestSkillRespec` was passed an object, not a display.

also adds dialog modals to confirm respec, and ask if player wants to open skill menu when respec is complete (saves the player having to perform a scroll wheel interaction)

## skill menu route
### modal 1

![204AC2~1](https://github.com/user-attachments/assets/087e7baf-42a4-46b0-b414-843113f080df)

### modal 2

![20CFD3~1](https://github.com/user-attachments/assets/1844e85d-6494-49ff-be02-48fed4e7bf28)

## addaction route
### modal 1

![20C236~1](https://github.com/user-attachments/assets/884fb4fb-1661-4f57-b3bf-f06fc7265da0)

### modal 2

![202104~1](https://github.com/user-attachments/assets/fbeff047-03f3-4dca-bed6-b121d20ca7db)
